### PR TITLE
Add container image library page and navigation

### DIFF
--- a/docs/container-library.md
+++ b/docs/container-library.md
@@ -1,0 +1,8 @@
+# Container Image Library
+
+This page will catalog available container images.
+
+## Available Images
+
+- TODO: Add container descriptions and links.
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -40,12 +40,12 @@
   </div>
 
   <div class="library-item">
-    <a href="https://textbook.esiil.org" target="_blank">
-      <img src="https://github.com/CU-ESIIL/home/blob/main/docs/assets/thumbnails/advanced_textbook.jpeg?raw=true" alt="Tutorials and Learning Resources">
+    <a href="./container-library/">
+      <img src="https://github.com/CU-ESIIL/home/blob/main/docs/assets/thumbnails/docker.jpeg?raw=true" alt="Container Image Library">
     </a>
     <p><strong>Container Image Library</strong></p>
-    <p>Comprehensive guide to environmental data science.</p>
-    <a href="https://textbook.esiil.org" target="_blank">🔗 Read the Textbook</a>
+    <p>Browse available container images for ESIIL computing.</p>
+    <a href="./container-library/">🔗 Explore Container Images</a>
   </div>
 
   <div class="library-item">

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,6 +13,7 @@ copyright: 'Copyright &copy; 2024 University of Colorado Boulder'
 # Page tree
 nav: 
   - OASIS: index.md
+  - Container Library: container-library.md
   
 # Configuration
 theme:


### PR DESCRIPTION
## Summary
- add placeholder Container Image Library page
- register container library page in mkdocs navigation
- link home page to the new container library page with updated description

## Testing
- `mkdocs serve >/tmp/mkdocs.log 2>&1 &` and verified pages via `curl`

------
https://chatgpt.com/codex/tasks/task_e_689cbffe8bd48325a194f97bb2dfe5d3