### PR TITLE
Add Quickstart page and image link

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -11,9 +11,11 @@
     <p>Welcome to the <strong>OASIS</strong>, a hub for open analysis and synthesis in <strong>Environmental Data Science</strong>.</p>
 </div>
 
-<!-- Quick Start Button -->
+<!-- Quick Start Image Link -->
 <div class="quick-start">
-  <a href="https://quickstart.esiil.org" class="quick-start-button" target="_blank">🚀 Quick Start</a>
+  <a href="./quickstart/">
+    <img src="assets/launch-terminal.png" alt="Quickstart">
+  </a>
 </div>
 
 ---

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,3 @@
+# Quickstart
+
+Welcome to the Quickstart guide. This page will collect resources to help you begin using the platform.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,8 +11,9 @@ edit_uri: edit/main/docs/
 copyright: 'Copyright &copy; 2024 University of Colorado Boulder'
 
 # Page tree
-nav: 
+nav:
   - OASIS: index.md
+  - Quickstart: quickstart.md
   - Container Library: container-library.md
   
 # Configuration


### PR DESCRIPTION
## Summary
- Replace Quickstart button on home page with an image that links internally
- Add Quickstart landing page and include it in site navigation

## Testing
- `mkdocs build`

------
https://chatgpt.com/codex/tasks/task_e_689cce55d85883259175748a366ec5c6