### PR TITLE
docs: expand quickstart homepage

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,3 +1,182 @@
-# Quickstart
+<!-- Static Header Section -->
+<div class="static-header">
+    <img id="header-img" src="https://raw.githubusercontent.com/CU-ESIIL/home/main/docs/assets/thumbnails/OASIS_header.png" 
+         alt="OASIS Header">
+</div>
 
-Welcome to the Quickstart guide. This page will collect resources to help you begin using the platform.
+<!-- Main Content -->
+<div class="content">
+    <h1 class="oasis-header">Quickstart Guide</h1>
+    <p>Jump into the <strong>OASIS</strong> ecosystem with these starter resources.</p>
+</div>
+
+---
+## 🚀 Getting Started
+
+<div class="gallery">
+  <div class="gallery-item">
+    <a href="https://www.cyverse.org/" target="_blank">
+      <img src="assets/thumbnails/cyverse_utils.jpeg?raw=true" alt="CyVerse">
+    </a>
+    <p><strong>Starting with CyVerse</strong></p>
+    <p>Provision cloud storage and compute.</p>
+  </div>
+
+  <div class="gallery-item">
+    <a href="https://www.r-project.org/" target="_blank">
+      <img src="https://www.r-project.org/logo/Rlogo.png" alt="R">
+    </a>
+    <p><strong>Starting with R</strong></p>
+    <p>Install R & RStudio for data analysis.</p>
+  </div>
+
+  <div class="gallery-item">
+    <a href="https://www.python.org/" target="_blank">
+      <img src="https://www.python.org/static/community_logos/python-logo.png" alt="Python">
+    </a>
+    <p><strong>Starting with Python</strong></p>
+    <p>Manage environments with Conda or virtualenv.</p>
+  </div>
+
+  <div class="gallery-item">
+    <a href="https://github.com/" target="_blank">
+      <img src="https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png" alt="GitHub">
+    </a>
+    <p><strong>Starting with GitHub</strong></p>
+    <p>Version control for collaboration.</p>
+  </div>
+
+  <div class="gallery-item">
+    <a href="https://www.docker.com/" target="_blank">
+      <img src="assets/thumbnails/docker.jpeg?raw=true" alt="Docker">
+    </a>
+    <p><strong>Starting Docker Containers</strong></p>
+    <p>Create reproducible environments.</p>
+  </div>
+
+  <div class="gallery-item">
+    <a href="./">
+      <img src="assets/thumbnails/esiil_oasis_logo.png" alt="OASIS">
+    </a>
+    <p><strong>Starting with OASIS</strong></p>
+    <p>Explore open science workflows.</p>
+  </div>
+</div>
+
+<style>
+  .gallery {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 20px;
+    justify-content: center;
+  }
+  .gallery-item {
+    width: calc(100% / 2 - 20px);
+    text-align: center;
+  }
+  .gallery-item img {
+    width: 100%;
+    max-width: 150px;
+    border-radius: 10px;
+    object-fit: cover;
+  }
+  @media (min-width: 600px) {
+    .gallery-item { width: calc(100% / 3 - 20px); }
+  }
+</style>
+
+---
+## 📚 Data & Analytics Libraries
+<div class="library-gallery">
+  <div class="library-item">
+    <a href="https://cu-esiil.github.io/data-library/" target="_blank">
+      <img src="https://github.com/CU-ESIIL/home/blob/main/docs/assets/thumbnails/data_library.jpeg?raw=true" alt="Data Library">
+    </a>
+    <p><strong>Data Library</strong></p>
+    <p>Organizational hub for ESIIL datasets.</p>
+    <a href="https://cu-esiil.github.io/data-library/" target="_blank">🔗 Visit Data Library</a>
+  </div>
+
+  <div class="library-item">
+    <a href="https://analytics-library.esiil.org" target="_blank">
+      <img src="https://github.com/CU-ESIIL/home/blob/main/docs/assets/thumbnails/analytics_library.jpeg?raw=true" alt="Analytics Library">
+    </a>
+    <p><strong>Analytics Library</strong></p>
+    <p>Repository for data harmonization and analytics.</p>
+    <a href="https://analytics-library.esiil.org" target="_blank">🔗 Visit Analytics Library</a>
+  </div>
+
+  <div class="library-item">
+    <a href="./container-library/">
+      <img src="https://github.com/CU-ESIIL/home/blob/main/docs/assets/thumbnails/docker.jpeg?raw=true" alt="Container Image Library">
+    </a>
+    <p><strong>Container Image Library</strong></p>
+    <p>Browse available container images for ESIIL computing.</p>
+    <a href="./container-library/">🔗 Explore Container Images</a>
+  </div>
+
+  <div class="library-item">
+    <a href="https://textbook.esiil.org" target="_blank">
+      <img src="https://github.com/CU-ESIIL/home/blob/main/docs/assets/thumbnails/advanced_textbook.jpeg?raw=true" alt="Advanced Textbook">
+    </a>
+    <p><strong>Advanced Textbook</strong></p>
+    <p>Comprehensive guide to environmental data science.</p>
+    <a href="https://textbook.esiil.org" target="_blank">🔗 Read the Textbook</a>
+  </div>
+</div>
+
+<style>
+  .library-gallery {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 20px;
+    justify-content: center;
+  }
+  .library-item {
+    width: calc(100% / 2 - 20px);
+    text-align: center;
+  }
+  .library-item img {
+    width: 100%;
+    max-width: 150px;
+    border-radius: 10px;
+    object-fit: cover;
+    height: auto;
+  }
+  @media (min-width: 600px) {
+    .library-item { width: calc(100% / 4 - 20px); }
+  }
+</style>
+
+---
+## 🏷️ Tags & Badges
+**ESIIL Tags** help categorize content for easier discovery. Use them to describe ecosystems, data types, or analytical approaches.
+
+**OASIS Tags** are general, ESIIL-defined categories that promote consistency across projects.
+
+Display **Badges** to recognize completion of trainings or contributions.
+
+---
+## 🤝 How to contribute
+Fork the repository, work on your feature, and open a pull request. Review `CONTRIBUTING.md` for detailed guidelines.
+
+---
+## 📄 README file
+Maintain the top-level `README.md` so newcomers understand the project's purpose, structure, and how to get involved.
+
+---
+## 🔍 Keywords
+Use specific, user-defined keywords to improve searchability and organization.
+
+---
+## 📝 How to cite this repo
+If you use this repository, please cite it:
+
+> Project Name. YEAR. Repository name. URL. Accessed DATE.
+
+## 📚 Links to related publications
+- Author A, Author B. YEAR. *Title of related publication*. Journal. DOI.
+- Author C. YEAR. *Another relevant work*. Journal. DOI.
+
+## 🆔 How to create a DOI
+Use services like [Zenodo](https://zenodo.org/) to archive releases and mint a DOI for your project.


### PR DESCRIPTION
## Summary
- replace text-heavy quickstart page with image galleries and styled sections
- highlight starter resources, libraries, tagging, and citation guidance

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689cdf685030832597dd5e03046f44e5