### PR TITLE
docs: expand data library quickstart guides

### DIFF
--- a/docs/quickstart/data-library.md
+++ b/docs/quickstart/data-library.md
@@ -1,5 +1,0 @@
-# Data Library
-
-Organizational hub for ESIIL datasets.
-
-Visit the [Data Library](https://cu-esiil.github.io/data-library/) to browse curated datasets.

--- a/docs/quickstart/data-library/how-to-contribute.md
+++ b/docs/quickstart/data-library/how-to-contribute.md
@@ -1,0 +1,21 @@
+---
+tags:
+  - data library
+  - quickstart
+  - contribution
+---
+
+# How to Contribute to the Data Library
+
+Help expand the Data Library by sharing datasets and improvements.
+
+1. Visit the [Data Library repository](https://github.com/CU-ESIIL/data-library).
+2. Fork the repository and add your dataset or edits following the contribution guidelines.
+3. Submit a pull request describing your changes.
+4. For questions, open an issue or contact the ESIIL team.
+
+---
+
+<div class="tagline">
+  Tags: data library, quickstart, contribution
+</div>

--- a/docs/quickstart/data-library/how-to-use.md
+++ b/docs/quickstart/data-library/how-to-use.md
@@ -1,0 +1,21 @@
+---
+tags:
+  - data library
+  - quickstart
+  - usage
+---
+
+# How to Use the Data Library
+
+The Data Library provides access to curated datasets maintained by ESIIL.
+
+1. Navigate to the [Data Library](https://cu-esiil.github.io/data-library/).
+2. Browse or search to locate a dataset of interest.
+3. Each dataset page includes metadata and code snippets for downloading data in R or Python.
+4. Follow any linked tutorials for more detailed analysis steps.
+
+---
+
+<div class="tagline">
+  Tags: data library, quickstart, usage
+</div>

--- a/docs/quickstart/data-library/index.md
+++ b/docs/quickstart/data-library/index.md
@@ -1,0 +1,16 @@
+# Data Library
+
+Organizational hub for ESIIL datasets.
+
+Visit the [Data Library](https://cu-esiil.github.io/data-library/) to browse curated datasets.
+
+## Guides
+
+- [How to Use the Data Library](how-to-use.md)
+- [How to Contribute to the Data Library](how-to-contribute.md)
+
+---
+
+<div class="tagline">
+  Tags: data library, quickstart
+</div>


### PR DESCRIPTION
## Summary
- restructure data library quickstart page and add links to usage and contribution guides
- document how to use the data library with step-by-step instructions
- document how to contribute datasets to the data library

## Testing
- `pytest`
- `mkdocs build`


------
https://chatgpt.com/codex/tasks/task_e_689cee487c58832597a0cd812c510325