### PR TITLE
Add analytics and container library docs

### DIFF
--- a/docs/analytics-library/esiil-analytics-library.md
+++ b/docs/analytics-library/esiil-analytics-library.md
@@ -1,0 +1,7 @@
+---
+title: Analytics Library Index
+---
+
+# Analytics Library Index
+
+The Analytics Library includes reusable workflows for data harmonization and analysis. Each workflow page is tagged to aid discovery.

--- a/docs/analytics-library/example-workflow.md
+++ b/docs/analytics-library/example-workflow.md
@@ -1,0 +1,7 @@
+---
+tags: [analytics, example]
+---
+
+# Example Workflow
+
+This placeholder demonstrates how analytics workflows can be documented and tagged for search.

--- a/docs/analytics-library/index.md
+++ b/docs/analytics-library/index.md
@@ -1,0 +1,5 @@
+# Analytics Library
+
+Repository for data harmonization and analytics workflows.
+
+This section makes analytic workflows discoverable from the OASIS search. Explore workflows below or visit the [full Analytics Library](https://analytics-library.esiil.org).

--- a/docs/container-library/esiil-container-library.md
+++ b/docs/container-library/esiil-container-library.md
@@ -1,0 +1,7 @@
+---
+title: Container Image Library Index
+---
+
+# Container Image Library Index
+
+The Container Image Library catalogs ready-to-use Docker images. Each image page is tagged to support search and discovery.

--- a/docs/container-library/example-container.md
+++ b/docs/container-library/example-container.md
@@ -1,0 +1,7 @@
+---
+tags: [container, example]
+---
+
+# Example Container
+
+This placeholder documents a sample container image and demonstrates tagging for search.

--- a/docs/container-library/index.md
+++ b/docs/container-library/index.md
@@ -1,0 +1,3 @@
+# Container Image Library
+
+Browse available container images for ESIIL computing. Use these images to run analyses in consistent environments.

--- a/docs/quickstart/container-library.md
+++ b/docs/quickstart/container-library.md
@@ -2,4 +2,4 @@
 
 Browse available container images for ESIIL computing.
 
-Explore the [Container Image Library](../container-library/) for ready-to-use container images.
+Explore the [Container Image Library](../container-library/index.md) for ready-to-use container images.


### PR DESCRIPTION
## Summary
- scaffold analytics library docs with searchable placeholder pages
- scaffold container image library docs and update quickstart link

## Testing
- `python -m mkdocs build`

------
https://chatgpt.com/codex/tasks/task_e_689cf1cac28083259f3f801173d5437a