### PR TITLE
Add tag cloud to analytics library homepage

### DIFF
--- a/docs/analytics-library/index.md
+++ b/docs/analytics-library/index.md
@@ -3,3 +3,10 @@
 Repository for data harmonization and analytics workflows.
 
 This section makes analytic workflows discoverable from the OASIS search. Explore workflows below or visit the [full Analytics Library](https://analytics-library.esiil.org).
+
+## Browse by tag
+
+<div class="tag-cloud">
+  <a href="esiil-analytics-library.md#analytics">analytics</a>
+  <a href="esiil-analytics-library.md#example">example</a>
+</div>

--- a/docs/assets/css/style.css
+++ b/docs/assets/css/style.css
@@ -100,3 +100,19 @@
 
 
 
+
+/* Tag cloud styling */
+.tag-cloud {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.tag-cloud a {
+  text-decoration: none;
+  background-color: var(--md-accent-fg-color, #e0e0e0);
+  color: var(--md-accent-bg-color, #000);
+  padding: 0.2rem 0.4rem;
+  border-radius: 0.25rem;
+  font-size: 0.85rem;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -114,7 +114,7 @@ extra_javascript:
 plugins:
   - search
   - tags:
-      tags_file: data-library/esiil-data-library.md
+      tags_file: analytics-library/esiil-analytics-library.md
   - mkdocstrings
   - git-revision-date
   - mkdocs-jupyter:


### PR DESCRIPTION
## Summary
- Add tag cloud links to analytics library homepage
- Style tag cloud and configure tags plugin for analytics library

## Testing
- `mkdocs build`

------
https://chatgpt.com/codex/tasks/task_e_689cfa9a113883258c02cc946670c5cc