### PR TITLE
Convert quickstart page to markdown

### DIFF
--- a/docs/quickstart/index.md
+++ b/docs/quickstart/index.md
@@ -1,15 +1,11 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Quickstart – OASIS</title>
+---
+title: Quick Start
+---
 
-  <!-- Overpass font (works on GitHub Pages) -->
-  <link href="https://fonts.googleapis.com/css2?family=Overpass:wght@400;600;700;800&display=swap" rel="stylesheet">
+<style>
+@import url('https://fonts.googleapis.com/css2?family=Overpass:wght@400;600;700;800&display=swap');
 
-  <style>
-    :root{
+:root{
       --navy:#0f2747;
       --sky:#7db6ff;
       --ink:#0b1220;
@@ -87,10 +83,9 @@
       .label{font-size:1rem}
       .icon{width:30px;height:30px}
     }
-  </style>
-</head>
-<body>
-  <header class="hero">
+</style>
+
+<header class="hero">
     <div class="hero-inner">
       <h1>Quick Start</h1>
       <p class="subtitle">Jump into OASIS with these starter resources</p>
@@ -238,5 +233,3 @@
       out.textContent = logs.join('\n');
     })();
   </script>
-</body>
-</html>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,6 +13,18 @@ copyright: 'Copyright &copy; 2024 University of Colorado Boulder'
 # Page tree
 nav:
   - OASIS: index.md
+  - Quickstart:
+      - Quick Start: quickstart/index.md
+      - Starting with CyVerse: quickstart/cyverse.md
+      - Starting with R: quickstart/r.md
+      - Starting with Python: quickstart/python.md
+      - Starting with GitHub: quickstart/github.md
+      - Starting Docker Container: quickstart/docker.md
+      - Starting with OASIS: quickstart/oasis.md
+      - Data Library: quickstart/data-library/index.md
+      - Analytics Library: quickstart/analytics-library.md
+      - Container Image Library: quickstart/container-library.md
+      - Advanced Textbook: quickstart/advanced-textbook.md
   
 # Configuration
 theme:


### PR DESCRIPTION
## Summary
- Convert Quickstart landing page from static HTML to Markdown with inline styling so it inherits MkDocs headers and sidebar
- Add Quickstart section and subpages to MkDocs navigation

## Testing
- `mkdocs build`

------
https://chatgpt.com/codex/tasks/task_e_689cfbff25e4832596f55a2856abc1f6