### PR TITLE
Add INLA spatial modeling example to analytics library

### DIFF
--- a/docs/analytics-library/index.md
+++ b/docs/analytics-library/index.md
@@ -6,3 +6,11 @@ This section makes analytic workflows discoverable from the OASIS search. Explor
 
 - [Spatial modeling in R with INLA](inla-spatial-example.md)
 - [Example Workflow](example-workflow.md)
+
+## Browse by tag
+
+<div class="tag-cloud">
+  <a href="esiil-analytics-library.md#analytics">analytics</a>
+  <a href="esiil-analytics-library.md#example">example</a>
+</div>
+

--- a/docs/analytics-library/index.md
+++ b/docs/analytics-library/index.md
@@ -1,5 +1,8 @@
 # Analytics Library
-
 Repository for data harmonization and analytics workflows.
-
 This section makes analytic workflows discoverable from the OASIS search. Explore workflows below or visit the [full Analytics Library](https://analytics-library.esiil.org).
+
+## Workflows
+
+- [Spatial modeling in R with INLA](inla-spatial-example.md)
+- [Example Workflow](example-workflow.md)

--- a/docs/analytics-library/inla-spatial-example.md
+++ b/docs/analytics-library/inla-spatial-example.md
@@ -1,0 +1,70 @@
+---
+title: Spatial modeling in R with INLA
+myst:
+  html_meta:
+    description: 'Spatial Bayesian analysis using the INLA package in R with a BYM model on areal data.'
+tags: [analytics, r, inla, spatial]
+---
+
+# Spatial Modeling with INLA in R
+
+The Integrated Nested Laplace Approximation (INLA) package enables fast Bayesian inference for latent Gaussian models. This example follows the INLA documentation to fit a spatial Besag-York-Mollié (BYM) model to North Carolina sudden infant death syndrome (SIDS) counts.
+
+## Prerequisites
+
+- [R](https://www.r-project.org)
+- [INLA](https://www.r-inla.org) package
+- [`spdep`](https://CRAN.R-project.org/package=spdep), [`spData`](https://CRAN.R-project.org/package=spData), and [`sf`](https://CRAN.R-project.org/package=sf) packages for spatial data handling
+
+```r
+# install INLA from the project repository if needed
+if (!require(INLA)) {
+  install.packages("INLA", repos = "https://inla.r-inla-download.org/R/stable")
+  library(INLA)
+}
+```
+
+## Load data and build adjacency
+
+```r
+library(spdep)
+library(spData)
+library(sf)
+
+# county polygons and SIDS data
+nc <- st_read(system.file("shapes/nc.shp", package = "spData"), quiet = TRUE)
+
+# neighborhood structure and graph for INLA
+nb <- poly2nb(nc)
+INLA::nb2INLA("nc.adj", nb)   # writes adjacency file
+g <- INLA::inla.read.graph("nc.adj")
+
+nc$ID <- 1:nrow(nc)  # unique identifier for spatial random effect
+```
+
+## Fit a spatial BYM model
+
+The response is the 1974 SIDS counts (`SID74`) with births (`BIR74`) as the expected number of cases.
+
+```r
+formula <- SID74 ~ 1 + f(ID, model = "bym", graph = g)
+result <- inla(
+  formula,
+  family = "poisson",
+  data = nc,
+  E = BIR74,
+  control.predictor = list(compute = TRUE)
+)
+
+summary(result)
+```
+
+## Map fitted risks
+
+```r
+nc$fitted <- result$summary.fitted.values[, "mean"]
+plot(nc["fitted"], main = "Estimated SIDS risk")
+```
+
+This workflow demonstrates how INLA can be applied to spatial data for disease mapping or other areal analyses.
+


### PR DESCRIPTION
## Summary
- add a new analytics library page demonstrating a spatial Besag-York-Mollié model in R using INLA
- list workflows, including the INLA example, in the analytics library index

## Testing
- `pytest`
- `mkdocs build`

------
https://chatgpt.com/codex/tasks/task_e_689cfc91600083259120dd87003d1b20