### PR TITLE
Fix OASIS logo link across documentation

### DIFF
--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,9 +1,11 @@
 {% extends "base.html" %}
 
 {% block site_name %}
-  <img src="{{ base_url }}/assets/thumbnails/OASIS_header.png" 
-       alt="OASIS Logo" 
-       style="height: 40px; object-fit: contain;">
+  <a href="{{ nav.homepage.url | url }}">
+    <img id="header-img" src="{{ base_url }}/assets/thumbnails/OASIS_header.png"
+         alt="OASIS Logo"
+         style="height: 40px; object-fit: contain;">
+  </a>
 {% endblock %}
 
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -22,7 +22,6 @@ theme:
   font:
     text: 'Open Sans'
     code: 'Roboto Mono'
-  logo: 'assets/thumbnails/esiil_oasis_logo.png'
   favicon: 'assets/esiil_content/favicon.ico'
   # setting features for the navigation tab
   toc:


### PR DESCRIPTION
## Summary
- Use the OASIS header graphic for the site name and link it back to the homepage
- Remove the outdated theme logo so only the header graphic is shown

## Testing
- `mkdocs build`

------
https://chatgpt.com/codex/tasks/task_e_689cfd2bea8c8325baa9ff351737b55a