### PR TITLE
Expand quick start pages with onboarding content

### DIFF
--- a/docs/quickstart/advanced-textbook.md
+++ b/docs/quickstart/advanced-textbook.md
@@ -1,5 +1,15 @@
 # Advanced Textbook
 
-Comprehensive guide to environmental data science.
+## Sell It
+The Advanced Textbook offers in-depth lessons and interactive notebooks to level up your environmental data science skills.
 
-Read the [Advanced Textbook](https://textbook.esiil.org) for in-depth tutorials.
+## Show It
+Browse chapters that mix narrative, code, and exercises at the [Advanced Textbook site](https://textbook.esiil.org).
+
+## Do It
+1. Open the textbook and explore the table of contents.
+2. Choose a chapter relevant to your work.
+3. Launch an accompanying notebook and run the example code.
+
+## Review It
+Capture what you learned and bookmark sections to revisit or share with colleagues.

--- a/docs/quickstart/analytics-library.md
+++ b/docs/quickstart/analytics-library.md
@@ -1,5 +1,15 @@
 # Analytics Library
 
-Repository for data harmonization and analytics.
+## Sell It
+The Analytics Library hosts reusable workflows and functions so you can build analyses faster and with consistent methods.
 
-Access the [Analytics Library](https://analytics-library.esiil.org) for reusable analysis workflows.
+## Show It
+Each workflow includes documented steps and example outputs at the [Analytics Library](https://analytics-library.esiil.org).
+
+## Do It
+1. Explore the library and pick a workflow that fits your project.
+2. Follow the README to install dependencies.
+3. Run the workflow on your own data to reproduce the example.
+
+## Review It
+Compare your results to the example outputs and consider contributing improvements or new workflows.

--- a/docs/quickstart/container-library.md
+++ b/docs/quickstart/container-library.md
@@ -1,5 +1,15 @@
 # Container Image Library
 
-Browse available container images for ESIIL computing.
+## Sell It
+Pre-built container images give you ready-to-run environments without installing software on your machine.
 
-Explore the [Container Image Library](../container-library/index.md) for ready-to-use container images.
+## Show It
+The [Container Image Library](../container-library/index.md) lists images with descriptions and tags; pull one with Docker to see a fully configured environment.
+
+## Do It
+1. Browse the library to choose an image.
+2. Use `docker pull <image>` to download it.
+3. Run it with `docker run -it <image> /bin/bash`.
+
+## Review It
+Check the tools inside the container and note which images fit your workflow for future projects.

--- a/docs/quickstart/cyverse.md
+++ b/docs/quickstart/cyverse.md
@@ -1,5 +1,16 @@
 # Starting with CyVerse
 
-Provision cloud storage and compute.
+## Sell It
+CyVerse provides free cloud storage and computing so you can scale analyses without managing local infrastructure.
 
-[CyVerse](https://www.cyverse.org/) provides cyberinfrastructure for life sciences. Use it to store and analyze data in the cloud.
+## Show It
+The CyVerse Discovery Environment offers a web workspace where you can manage data and launch apps.
+
+## Do It
+1. Register for a free account at [CyVerse](https://www.cyverse.org/).
+2. Log in to the Discovery Environment.
+3. Upload a small dataset or try a sample app.
+
+## Review It
+Ensure your files appear in your account and explore the available apps to plan your next analysis.
+

--- a/docs/quickstart/data-library/how-to-contribute.md
+++ b/docs/quickstart/data-library/how-to-contribute.md
@@ -7,15 +7,17 @@ tags:
 
 # How to Contribute to the Data Library
 
-Help expand the Data Library by sharing datasets and improvements.
+## Sell It
+Sharing datasets expands the community's resources and promotes reproducible research.
 
-1. Visit the [Data Library repository](https://github.com/CU-ESIIL/data-library).
-2. Fork the repository and add your dataset or edits following the contribution guidelines.
-3. Submit a pull request describing your changes.
-4. For questions, open an issue or contact the ESIIL team.
+## Show It
+The Data Library repository uses GitHub pull requests so contributions are transparent and trackable.
 
----
+## Do It
+1. Visit the [Data Library repository](https://github.com/CU-ESIIL/data-library) and fork it.
+2. Add your dataset and metadata following the contribution guidelines.
+3. Commit your changes and open a pull request.
 
-<div class="tagline">
-  Tags: data library, quickstart, contribution
-</div>
+## Review It
+Link your pull request in an issue or discussion and watch for feedback from maintainers.
+

--- a/docs/quickstart/data-library/how-to-use.md
+++ b/docs/quickstart/data-library/how-to-use.md
@@ -7,15 +7,17 @@ tags:
 
 # How to Use the Data Library
 
-The Data Library provides access to curated datasets maintained by ESIIL.
+## Sell It
+The Data Library lets you discover curated datasets maintained by ESIIL, saving time on searching and cleaning data.
 
+## Show It
+Each dataset page includes rich metadata and code snippets for R or Python to load the data directly.
+
+## Do It
 1. Navigate to the [Data Library](https://cu-esiil.github.io/data-library/).
-2. Browse or search to locate a dataset of interest.
-3. Each dataset page includes metadata and code snippets for downloading data in R or Python.
-4. Follow any linked tutorials for more detailed analysis steps.
+2. Browse or search for a dataset of interest.
+3. Copy the provided code snippet and run it in your environment to download the data.
 
----
+## Review It
+Check that the dataset loads correctly in your session and note any questions or improvements to share with the community.
 
-<div class="tagline">
-  Tags: data library, quickstart, usage
-</div>

--- a/docs/quickstart/data-library/index.md
+++ b/docs/quickstart/data-library/index.md
@@ -1,16 +1,18 @@
 # Data Library
 
-Organizational hub for ESIIL datasets.
+## Sell It
+The Data Library is ESIIL's central hub for sharing vetted datasets so you can start analyzing immediately.
 
-Visit the [Data Library](https://cu-esiil.github.io/data-library/) to browse curated datasets.
+## Show It
+Visit a dataset page to see descriptive metadata and copy-and-paste code snippets, like on the [library homepage](https://cu-esiil.github.io/data-library/).
 
-## Guides
+## Do It
+1. Head to the [Data Library](https://cu-esiil.github.io/data-library/).
+2. Use search or tags to find a dataset.
+3. Follow the dataset's instructions or linked tutorials to download and explore it.
 
+## Review It
+Reflect on how the dataset fits your project and explore the guides:
 - [How to Use the Data Library](how-to-use.md)
 - [How to Contribute to the Data Library](how-to-contribute.md)
 
----
-
-<div class="tagline">
-  Tags: data library, quickstart
-</div>

--- a/docs/quickstart/docker.md
+++ b/docs/quickstart/docker.md
@@ -1,5 +1,22 @@
 # Starting Docker Containers
 
-Create reproducible environments.
+## Sell It
+Docker packages software and dependencies into portable containers that run consistently anywhere.
 
-Install [Docker](https://www.docker.com/) to build and run containers for consistent software setups.
+## Show It
+A simple `Dockerfile` defines an environment:
+
+```Dockerfile
+FROM python:3.11-slim
+COPY . /app
+RUN pip install -r requirements.txt
+```
+
+## Do It
+1. Install [Docker](https://www.docker.com/) for your operating system.
+2. Create a `Dockerfile` like the example above or pull an existing image.
+3. Build it with `docker build -t myimage .`.
+4. Run the container using `docker run -it myimage`.
+
+## Review It
+List containers with `docker ps` to confirm it ran and note how reproducible the environment is for future projects.

--- a/docs/quickstart/github.md
+++ b/docs/quickstart/github.md
@@ -1,5 +1,16 @@
 # Starting with GitHub
 
-Version control for collaboration.
+## Sell It
+GitHub keeps your code safe, tracks every change, and makes teamwork simple.
 
-Visit [GitHub](https://github.com/) to create repositories and collaborate on code.
+## Show It
+A repository page displays your files, commit history, and issues in one place so everyone can follow progress.
+
+## Do It
+1. Create a free account at [GitHub](https://github.com/).
+2. Install [Git](https://git-scm.com/) on your computer.
+3. Clone a repository or start a new one with `git init`.
+4. Commit a change and push it to GitHub.
+
+## Review It
+Visit your repository on GitHub to confirm the commit appears and invite a teammate to collaborate or open an issue.

--- a/docs/quickstart/oasis.md
+++ b/docs/quickstart/oasis.md
@@ -1,5 +1,15 @@
 # Starting with OASIS
 
-Explore open science workflows.
+## Sell It
+OASIS is ESIIL's platform for open science workflows, linking datasets, code, and computing resources in one place.
 
-The OASIS platform supports environmental data science projects across ESIIL. Learn more on the [OASIS homepage](../index.md).
+## Show It
+A typical OASIS project combines documentation and runnable notebooks to share reproducible research.
+
+## Do It
+1. Visit the [OASIS homepage](../index.md) and sign in.
+2. Create a new project or explore an existing one.
+3. Launch an analysis notebook to see how data and code connect.
+
+## Review It
+Verify that you can open and run the sample notebook, and consider how OASIS can host your own project.

--- a/docs/quickstart/python.md
+++ b/docs/quickstart/python.md
@@ -1,5 +1,21 @@
 # Starting with Python
 
-Manage environments with Conda or virtualenv.
+## Sell It
+Python is a flexible language with a rich ecosystem of libraries for data science and automation.
 
-Learn more at the [Python](https://www.python.org/) website and explore environment tools like [Conda](https://docs.conda.io/en/latest/) or [virtualenv](https://virtualenv.pypa.io/).
+## Show It
+A minimal script prints a message:
+
+```python
+print("Hello, OASIS!")
+```
+
+## Do It
+1. Install Python from the [official site](https://www.python.org/).
+2. Create an environment with `conda create -n myenv python` or `python -m venv myenv`.
+3. Activate the environment and run `python` to enter the interpreter.
+4. Execute the script above to verify it works.
+
+## Review It
+Run `python --version` and ensure the environment isolates packages for your project.
+

--- a/docs/quickstart/r.md
+++ b/docs/quickstart/r.md
@@ -1,5 +1,20 @@
 # Starting with R
 
-Install R and RStudio for data analysis.
+## Sell It
+R is a powerful language for statistics and visualization with an active community.
 
-Get started by downloading [R](https://www.r-project.org/) and installing an IDE like [RStudio](https://posit.co/download/rstudio-desktop/).
+## Show It
+An example script plots built-in data:
+
+```r
+plot(cars)
+```
+
+## Do It
+1. Download and install [R](https://www.r-project.org/).
+2. Install [RStudio](https://posit.co/download/rstudio-desktop/) for an integrated development environment.
+3. Open RStudio and run the example script in the console.
+
+## Review It
+Check the plot output and use `sessionInfo()` to confirm your R setup.
+


### PR DESCRIPTION
## Summary
- Add "Sell It, Show It, Do It, Review It" sections to Quick Start pages for GitHub, Docker, Python, R, CyVerse, OASIS, Analytics Library, Container Image Library, and Advanced Textbook.
- Rework Data Library index and guides with the same structured onboarding format.

## Testing
- `pytest`
- `mkdocs build`


------
https://chatgpt.com/codex/tasks/task_e_689d001ea20483258bf8b58da00ab1f6