### PR TITLE
Use ESIIL OASIS logo in site header

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,7 @@
 <!-- Static Header Section -->
 <div class="static-header">
-    <img id="header-img" src="https://raw.githubusercontent.com/CU-ESIIL/home/main/docs/assets/thumbnails/OASIS_header.png" 
-         alt="OASIS Header">
+    <img id="header-img" src="https://raw.githubusercontent.com/CU-ESIIL/home/main/docs/assets/thumbnails/esiil_oasis_logo.png"
+         alt="ESIIL OASIS Header">
 </div>
 
 

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -2,8 +2,8 @@
 
 {% block site_name %}
   <a href="{{ nav.homepage.url | url }}">
-    <img id="header-img" src="{{ base_url }}/assets/thumbnails/OASIS_header.png"
-         alt="OASIS Logo"
+    <img id="header-img" src="{{ base_url }}/assets/thumbnails/esiil_oasis_logo.png"
+         alt="ESIIL OASIS Logo"
          style="height: 40px; object-fit: contain;">
   </a>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Display ESIIL OASIS logo in the site header
- Update homepage banner to use the same ESIIL OASIS logo

## Testing
- `mkdocs build`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d0295a4748325bb3503c8fc366644