### PR TITLE
Add tag-based sidebar for subject navigation

### DIFF
--- a/docs/analytics-library/example-workflow.md
+++ b/docs/analytics-library/example-workflow.md
@@ -1,5 +1,5 @@
 ---
-tags: [analytics, example]
+tags: [analytics, example, raster]
 ---
 
 # Example Workflow

--- a/docs/assets/css/style.css
+++ b/docs/assets/css/style.css
@@ -116,3 +116,34 @@
   border-radius: 0.25rem;
   font-size: 0.85rem;
 }
+
+/* Tag sidebar styling */
+.tag-sidebar {
+  position: fixed;
+  top: 120px;
+  right: 10px;
+  width: 200px;
+  background: #f5f5f5;
+  padding: 10px;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.tag-sidebar ul {
+  list-style: none;
+  padding-left: 0;
+  margin: 0;
+}
+
+.tag-sidebar li {
+  margin-bottom: 6px;
+}
+
+.tag-sidebar a {
+  text-decoration: none;
+  color: #333;
+}
+
+.tag-sidebar a:hover {
+  text-decoration: underline;
+}

--- a/docs/container-library/example-container.md
+++ b/docs/container-library/example-container.md
@@ -1,5 +1,5 @@
 ---
-tags: [container, example]
+tags: [container, example, raster]
 ---
 
 # Example Container

--- a/docs/data-library/lcmap.md
+++ b/docs/data-library/lcmap.md
@@ -3,6 +3,7 @@ tags:
   - landcover
   - usgs
   - remote-sensing
+  - raster
 ---
 
 # Land Change Monitoring, Assessment, and Projection

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,22 @@
+---
+hide:
+  - toc
+---
+
 <!-- Static Header Section -->
 <div class="static-header">
     <img id="header-img" src="https://raw.githubusercontent.com/CU-ESIIL/home/main/docs/assets/thumbnails/OASIS_header.png"
          alt="ESIIL OASIS Header">
+</div>
+
+<div class="tag-sidebar">
+  <h3>Subject Areas</h3>
+  <ul>
+    <li><a href="./tags/raster/">Raster Data</a></li>
+    <li><a href="./tags/analytics/">Analytics</a></li>
+    <li><a href="./tags/container/">Containers</a></li>
+    <li><a href="./tags/education/">Education</a></li>
+  </ul>
 </div>
 
 

--- a/docs/quickstart/advanced-textbook.md
+++ b/docs/quickstart/advanced-textbook.md
@@ -1,3 +1,7 @@
+---
+tags: [education, raster]
+---
+
 # Advanced Textbook
 
 ## Sell It


### PR DESCRIPTION
## Summary
- Replace home page table of contents with a tag-based sidebar linking to subject pages
- Style new sidebar and surface example tags for unified resource discovery
- Tag sample resources across libraries so `raster` shows items from data, container, analytics, and education sections

## Testing
- `PYTHONWARNINGS=ignore mkdocs build`

------
https://chatgpt.com/codex/tasks/task_e_689d0f0363848325bb7f5c6a1bed1287