### PR TITLE
Remove persistent tag sidebar

### DIFF
--- a/docs/assets/css/style.css
+++ b/docs/assets/css/style.css
@@ -117,33 +117,3 @@
   font-size: 0.85rem;
 }
 
-/* Tag sidebar styling */
-.tag-sidebar {
-  position: fixed;
-  top: 120px;
-  right: 10px;
-  width: 200px;
-  background: #f5f5f5;
-  padding: 10px;
-  border-radius: 8px;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-}
-
-.tag-sidebar ul {
-  list-style: none;
-  padding-left: 0;
-  margin: 0;
-}
-
-.tag-sidebar li {
-  margin-bottom: 6px;
-}
-
-.tag-sidebar a {
-  text-decoration: none;
-  color: #333;
-}
-
-.tag-sidebar a:hover {
-  text-decoration: underline;
-}

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,18 +8,6 @@ hide:
     <img id="header-img" src="https://raw.githubusercontent.com/CU-ESIIL/home/main/docs/assets/thumbnails/OASIS_header.png"
          alt="ESIIL OASIS Header">
 </div>
-
-<div class="tag-sidebar">
-  <h3>Subject Areas</h3>
-  <ul>
-    <li><a href="./tags/raster/">Raster Data</a></li>
-    <li><a href="./tags/analytics/">Analytics</a></li>
-    <li><a href="./tags/container/">Containers</a></li>
-    <li><a href="./tags/education/">Education</a></li>
-  </ul>
-</div>
-
-
 <!-- Main Content -->
 <div class="content">
     <h1 class="oasis-header">Open Analysis and Synthesis Infrastructure for Science</h1>


### PR DESCRIPTION
## Summary
- remove persistent tag sidebar from homepage
- drop related styling

## Testing
- `mkdocs build`

------
https://chatgpt.com/codex/tasks/task_e_689dece1c2888325a117eb8d4917f922