### PR TITLE
Add development schedule page with Gantt chart

### DIFF
--- a/docs/dev-schedule.md
+++ b/docs/dev-schedule.md
@@ -1,0 +1,52 @@
+# Development Schedule
+
+A collaborative timeline for OASIS development. Update this page through pull requests and link to contributions as tasks are completed.
+
+## Task List
+
+- [ ] [Draft development schedule page](https://github.com/CU-ESIIL/home/pull/TBD) — [@alice](https://github.com/alice), [@bob](https://github.com/bob)
+- [ ] [Add GitHub linking to tasks](https://github.com/CU-ESIIL/home/issues/TBD) — [@carol](https://github.com/carol)
+- [ ] [Automate Gantt chart updates](https://github.com/CU-ESIIL/home/issues/TBD) — [@dan](https://github.com/dan)
+
+## Timeline Overview
+
+| Task | Start | End | Contributors |
+|------|-------|-----|--------------|
+| Draft development schedule page | 2024-06-01 | 2024-06-03 | [@alice](https://github.com/alice), [@bob](https://github.com/bob) |
+| Add GitHub linking to tasks | 2024-06-04 | 2024-06-10 | [@carol](https://github.com/carol) |
+| Automate Gantt chart updates | 2024-06-11 | 2024-06-16 | [@dan](https://github.com/dan) |
+
+## Gantt Chart
+
+```mermaid
+gantt
+    title OASIS Development Timeline
+    dateFormat  YYYY-MM-DD
+    axisFormat  %b %d
+    section Planning
+    Draft schedule page     :done,    des1, 2024-06-01, 3d
+    section Features
+    GitHub link integration :active,  des2, 2024-06-04, 6d
+    Auto Gantt updates      :         des3, 2024-06-11, 5d
+```
+
+<style>
+  table {
+    width: 100%;
+    border-collapse: collapse;
+  }
+  th, td {
+    padding: 8px;
+    border-bottom: 1px solid #ddd;
+  }
+  tr:hover {
+    background-color: #f5f5f5;
+  }
+  .task-list li {
+    background: #f5f5f5;
+    border-radius: 8px;
+    padding: 0.5rem;
+    margin: 0.5rem 0;
+    list-style: none;
+  }
+</style>

--- a/docs/index.md
+++ b/docs/index.md
@@ -717,7 +717,15 @@ Repositories focused on software, data infrastructure, and computational tools.
     <p>Documenting known issues in CyVerse workflows.</p>
   </div>
 
-</div>
+  <div class="template-item">
+    <a href="./dev-schedule/" target="_blank">
+      <img src="https://github.com/CU-ESIIL/home/blob/main/docs/gantt_chart.png?raw=true" alt="Development Schedule">
+    </a>
+    <p><strong>Development Schedule</strong></p>
+    <p>Living task list and timeline for OASIS development.</p>
+  </div>
+
+  </div>
 
 <style>
   .template-gallery {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,6 +13,7 @@ copyright: 'Copyright &copy; 2024 University of Colorado Boulder'
 # Page tree
 nav:
   - OASIS: index.md
+  - Development Schedule: dev-schedule.md
   - Quickstart:
       - Quick Start: quickstart/index.md
       - Starting with CyVerse: quickstart/cyverse.md


### PR DESCRIPTION
## Summary
- add development schedule page with task list and mermaid Gantt chart
- link schedule from CI Infrastructure & Tools section
- expose page through MkDocs navigation

## Testing
- `pre-commit run --files docs/dev-schedule.md docs/index.md mkdocs.yml` *(fails: pre-commit not installed)*

------
https://chatgpt.com/codex/tasks/task_e_689e042758fc83259fe580ef2309041d