### PR TITLE
Use localized git dates and update Material emoji config

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,3 +19,8 @@ weight: 0.0       # optional, higher ranks first
 
 Run `pre-commit run --files <file.md>` before committing to ensure the metadata
 is present.
+
+## Revision dates
+
+Pages generated under `tags/` during the build are intentionally excluded from
+Git-based revision dates.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -91,8 +91,8 @@ markdown_extensions:
   - pymdownx.critic
   - pymdownx.details
   - pymdownx.emoji:
-      emoji_index: !!python/name:materialx.emoji.twemoji
-      emoji_generator: !!python/name:materialx.emoji.to_svg
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
   - pymdownx.highlight
   - pymdownx.inlinehilite
   - pymdownx.keys
@@ -132,7 +132,11 @@ plugins:
   - tags:
       tags_file: analytics-library/esiil-analytics-library.md
   - mkdocstrings
-  - git-revision-date
+  - git-revision-date-localized:
+      enable_creation_date: false
+      fallback_to_build_date: true
+      exclude:
+        - ^tags/.*
   - mkdocs-jupyter:
         include_source: True
         ignore_h1_titles: False

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,11 +11,11 @@ tox
 twine
 watchdog
 wheel
-mkdocs-git-revision-date-plugin 
-mkdocs-jupyter 
-mkdocs-material 
+mkdocs-git-revision-date-localized-plugin>=1.2
+mkdocs-jupyter
+mkdocs-material>=9.5
 mkdocs-pdf-export-plugin
-mkdocstrings 
+mkdocstrings
 mkdocstrings-crystal
 mkdocstrings-python-legacy
 
@@ -25,12 +25,12 @@ markdown>=3.2
 mkdocs==1.5.3
 mkdocs-material-extensions>=1.1
 pygments>=2.14
-pymdown-extensions>=9.9.1
+pymdown-extensions>=10
 
 # Requirements for plugins
 colorama>=0.4
 regex>=2022.4.24
 requests>=2.26
 
-mkdocs-gen-files
-pyyaml
+mkdocs-gen-files>=0.5
+PyYAML>=6

--- a/scripts/build_tags.py
+++ b/scripts/build_tags.py
@@ -64,12 +64,10 @@ json_payload = {
     "pages": [{k: v for k, v in p.items() if k != "_dt"} for p in pages],
     "tags": tags_sorted
 }
-os.makedirs("assets", exist_ok=True)
 with gen_open("assets/tags.json", "w") as f:
     json.dump(json_payload, f, indent=2, ensure_ascii=False)
 
 # Generate per-tag markdown pages ranked by date desc then weight desc
-os.makedirs("tags", exist_ok=True)
 for tag, items in tagmap.items():
     items_sorted = sorted(items, key=lambda x: (x["_dt"], x["weight"]), reverse=True)
     out_lines = [f"---\ntitle: {tag}\nhide:\n  - toc\n---\n", f"# {tag}\n"]


### PR DESCRIPTION
## Summary
- update emoji extension to Material v9 syntax
- switch to git-revision-date-localized plugin and ignore generated tag pages
- pin compatible dependency versions and avoid real directories for generated files

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement mkdocs-git-revision-date-localized-plugin>=1.2)*
- `mkdocs --version`
- `mkdocs build --strict` *(fails: cannot find module 'material.extensions')*
- `mkdocs serve` *(fails: cannot find module 'material.extensions')*


------
https://chatgpt.com/codex/tasks/task_e_689e05b798b8832594cf76d96fb886e9