### PR TITLE
fix: prevent sidebar text overlap

### DIFF
--- a/docs/assets/css/style.css
+++ b/docs/assets/css/style.css
@@ -86,6 +86,7 @@
   font-size: 16px;
   text-transform: uppercase;
   letter-spacing: 1px;
+  line-height: 1.4;
   color: rgba(211, 211, 211, 1) !important; /* Light Gray (211, 211, 211) with 80% opacity */
 }
 


### PR DESCRIPTION
## Summary
- ensure sidebar links have ample line height to stop overlapping text on the OASIS homepage

## Testing
- `mkdocs build`
- `pre-commit run --files docs/assets/css/style.css` *(fails: command not found, unable to install pre-commit due to proxy restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_689e46f2365483258a922fd760a07d87