### PR TITLE
ci: use Python 3.11 for docs build

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,21 +1,21 @@
- name: Publish docs via GitHub
- on:
-   push:
-     branches:
-       - main
+name: Publish docs via GitHub
+on:
+  push:
+    branches:
+      - main
 
- jobs:
-   build:
-     name: Deploy docs
-     runs-on: ubuntu-latest
-     steps:
-       - uses: actions/checkout@v3
-       - uses: actions/setup-python@v4
-         with:
-           python-version: 3.9
-       - name: run requirements file
-         run:  pip install -r requirements.txt 
-       - name: Deploy docs
-         run: mkdocs gh-deploy --force
-         env:
-           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+jobs:
+  build:
+    name: Deploy docs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: run requirements file
+        run: pip install -r requirements.txt
+      - name: Deploy docs
+        run: mkdocs gh-deploy --force
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
## Summary
- use Python 3.11 in GitHub Pages workflow so mkdocs tags plugin can install

## Testing
- `pip install -r requirements.txt` *(fails: Cannot connect to proxy)*
- `pre-commit run --files .github/workflows/gh-pages.yml` *(fails: command not found, pre-commit install blocked by proxy)*

------
https://chatgpt.com/codex/tasks/task_e_689e672542808325a495a9d3656117c1