### PR TITLE
ci: use Python 3.11 for docs build

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,21 +1,21 @@
- name: Publish docs via GitHub
- on:
-   push:
-     branches:
-       - main
+name: Publish docs via GitHub
+on:
+  push:
+    branches:
+      - main
 
- jobs:
-   build:
-     name: Deploy docs
-     runs-on: ubuntu-latest
-     steps:
-       - uses: actions/checkout@v3
-       - uses: actions/setup-python@v4
-         with:
-           python-version: 3.9
-       - name: run requirements file
-         run:  pip install -r requirements.txt 
-       - name: Deploy docs
-         run: mkdocs gh-deploy --force
-         env:
-           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+jobs:
+  build:
+    name: Deploy docs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: run requirements file
+        run: pip install -r requirements.txt
+      - name: Deploy docs
+        run: mkdocs gh-deploy --force
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,5 +34,5 @@ requests>=2.26
 
 mkdocs-gen-files>=0.5
 PyYAML>=6
-mkdocs-tags-plugin>=0.11
+mkdocs-tags-plugin
 pyyaml-include>=1.3


### PR DESCRIPTION
## Summary
- use Python 3.11 in GitHub Pages workflow so mkdocs tags plugin can install
- remove strict mkdocs-tags-plugin version requirement to allow installation of available releases

## Testing
- `pip install -r requirements.txt` *(fails: Could not connect to proxy)*
- `pre-commit run --files requirements.txt` *(fails: command not found; installing `pre-commit` fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_689e672542808325a495a9d3656117c1