### PR TITLE
Remove invalid mkdocs-tags-plugin dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -34,5 +34,4 @@ requests>=2.26
 
 mkdocs-gen-files>=0.5
 PyYAML>=6
-mkdocs-tags-plugin
 pyyaml-include>=1.3


### PR DESCRIPTION
## Summary
- drop nonexistent `mkdocs-tags-plugin` from `requirements.txt`

## Testing
- `pre-commit run --files requirements.txt` *(fails: command not found)*
- `pip install -r requirements.txt` *(fails: could not find a version for bump2version due to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_689fab4ae4e88325a3e7648708ec6686