### PR TITLE
Fix tag links to rendered docs

### DIFF
--- a/docs/tags/Bayesian.md
+++ b/docs/tags/Bayesian.md
@@ -6,5 +6,5 @@ hide:
 
 # Bayesian
 
-- [INLA — Drop-in Analytics Module](/analytics-library/inla.md)  
+- [INLA — Drop-in Analytics Module](/analytics-library/inla/)  
   <small></small>

--- a/docs/tags/GLMM.md
+++ b/docs/tags/GLMM.md
@@ -6,5 +6,5 @@ hide:
 
 # GLMM
 
-- [INLA — Drop-in Analytics Module](/analytics-library/inla.md)  
+- [INLA — Drop-in Analytics Module](/analytics-library/inla/)  
   <small></small>

--- a/docs/tags/INLA.md
+++ b/docs/tags/INLA.md
@@ -6,5 +6,5 @@ hide:
 
 # INLA
 
-- [INLA — Drop-in Analytics Module](/analytics-library/inla.md)  
+- [INLA — Drop-in Analytics Module](/analytics-library/inla/)  
   <small></small>

--- a/docs/tags/LGM.md
+++ b/docs/tags/LGM.md
@@ -6,5 +6,5 @@ hide:
 
 # LGM
 
-- [INLA — Drop-in Analytics Module](/analytics-library/inla.md)  
+- [INLA — Drop-in Analytics Module](/analytics-library/inla/)  
   <small></small>

--- a/docs/tags/R.md
+++ b/docs/tags/R.md
@@ -6,5 +6,5 @@ hide:
 
 # R
 
-- [INLA — Drop-in Analytics Module](/analytics-library/inla.md)  
+- [INLA — Drop-in Analytics Module](/analytics-library/inla/)  
   <small></small>

--- a/docs/tags/analytics.md
+++ b/docs/tags/analytics.md
@@ -6,7 +6,7 @@ hide:
 
 # analytics
 
-- [INLA — Drop-in Analytics Module](/analytics-library/inla.md)  
+- [INLA — Drop-in Analytics Module](/analytics-library/inla/)  
   <small></small>
-- [example-workflow](/analytics-library/example-workflow.md)  
+- [example-workflow](/analytics-library/example-workflow/)  
   <small></small>

--- a/docs/tags/biomass.md
+++ b/docs/tags/biomass.md
@@ -6,5 +6,5 @@ hide:
 
 # biomass
 
-- [gedi](/data-library/gedi.md)  
+- [gedi](/data-library/gedi/)  
   <small></small>

--- a/docs/tags/burn-severity.md
+++ b/docs/tags/burn-severity.md
@@ -6,5 +6,5 @@ hide:
 
 # burn-severity
 
-- [fire-cbi](/data-library/fire-cbi.md)  
+- [fire-cbi](/data-library/fire-cbi/)  
   <small></small>

--- a/docs/tags/climate.md
+++ b/docs/tags/climate.md
@@ -6,5 +6,5 @@ hide:
 
 # climate
 
-- [drought](/data-library/drought.md)  
+- [drought](/data-library/drought/)  
   <small></small>

--- a/docs/tags/cloud.md
+++ b/docs/tags/cloud.md
@@ -6,5 +6,5 @@ hide:
 
 # cloud
 
-- [mounting-via-vsi](/data-library/mounting-via-vsi.md)  
+- [mounting-via-vsi](/data-library/mounting-via-vsi/)  
   <small></small>

--- a/docs/tags/container.md
+++ b/docs/tags/container.md
@@ -6,5 +6,5 @@ hide:
 
 # container
 
-- [example-container](/container-library/example-container.md)  
+- [example-container](/container-library/example-container/)  
   <small></small>

--- a/docs/tags/contribution.md
+++ b/docs/tags/contribution.md
@@ -6,5 +6,5 @@ hide:
 
 # contribution
 
-- [how-to-contribute](/quickstart/data-library/how-to-contribute.md)  
+- [how-to-contribute](/quickstart/data-library/how-to-contribute/)  
   <small></small>

--- a/docs/tags/data library.md
+++ b/docs/tags/data library.md
@@ -6,7 +6,7 @@ hide:
 
 # data library
 
-- [how-to-use](/quickstart/data-library/how-to-use.md)  
+- [how-to-use](/quickstart/data-library/how-to-use/)  
   <small></small>
-- [how-to-contribute](/quickstart/data-library/how-to-contribute.md)  
+- [how-to-contribute](/quickstart/data-library/how-to-contribute/)  
   <small></small>

--- a/docs/tags/data-cubes.md
+++ b/docs/tags/data-cubes.md
@@ -6,5 +6,5 @@ hide:
 
 # data-cubes
 
-- [stac_mount_save](/data-library/stac_mount_save.md)  
+- [stac_mount_save](/data-library/stac_mount_save/)  
   <small></small>

--- a/docs/tags/data-management.md
+++ b/docs/tags/data-management.md
@@ -6,5 +6,5 @@ hide:
 
 # data-management
 
-- [move-data-to-instance](/data-library/move-data-to-instance.md)  
+- [move-data-to-instance](/data-library/move-data-to-instance/)  
   <small></small>

--- a/docs/tags/development.md
+++ b/docs/tags/development.md
@@ -6,5 +6,5 @@ hide:
 
 # development
 
-- [dev-schedule](/dev-schedule.md)  
+- [dev-schedule](/dev-schedule/)  
   <small>2025-08-14</small>

--- a/docs/tags/disturbance.md
+++ b/docs/tags/disturbance.md
@@ -6,7 +6,7 @@ hide:
 
 # disturbance
 
-- [disturbance-stack](/data-library/disturbance-stack.md)  
+- [landfire-events](/data-library/landfire-events/)  
   <small></small>
-- [landfire-events](/data-library/landfire-events.md)  
+- [disturbance-stack](/data-library/disturbance-stack/)  
   <small></small>

--- a/docs/tags/docker.md
+++ b/docs/tags/docker.md
@@ -6,5 +6,5 @@ hide:
 
 # docker
 
-- [Starting with OASIS](/quickstart/oasis.md)  
+- [Starting with OASIS](/quickstart/oasis/)  
   <small>2024-01-01</small>

--- a/docs/tags/drought.md
+++ b/docs/tags/drought.md
@@ -6,7 +6,7 @@ hide:
 
 # drought
 
-- [disturbance-stack](/data-library/disturbance-stack.md)  
+- [drought](/data-library/drought/)  
   <small></small>
-- [drought](/data-library/drought.md)  
+- [disturbance-stack](/data-library/disturbance-stack/)  
   <small></small>

--- a/docs/tags/ecoregions.md
+++ b/docs/tags/ecoregions.md
@@ -6,5 +6,5 @@ hide:
 
 # ecoregions
 
-- [epa-ecoregions](/data-library/epa-ecoregions.md)  
+- [epa-ecoregions](/data-library/epa-ecoregions/)  
   <small></small>

--- a/docs/tags/education.md
+++ b/docs/tags/education.md
@@ -6,5 +6,5 @@ hide:
 
 # education
 
-- [advanced-textbook](/quickstart/advanced-textbook.md)  
+- [advanced-textbook](/quickstart/advanced-textbook/)  
   <small></small>

--- a/docs/tags/epa.md
+++ b/docs/tags/epa.md
@@ -6,5 +6,5 @@ hide:
 
 # epa
 
-- [epa-ecoregions](/data-library/epa-ecoregions.md)  
+- [epa-ecoregions](/data-library/epa-ecoregions/)  
   <small></small>

--- a/docs/tags/example.md
+++ b/docs/tags/example.md
@@ -6,7 +6,7 @@ hide:
 
 # example
 
-- [example-container](/container-library/example-container.md)  
+- [example-workflow](/analytics-library/example-workflow/)  
   <small></small>
-- [example-workflow](/analytics-library/example-workflow.md)  
+- [example-container](/container-library/example-container/)  
   <small></small>

--- a/docs/tags/featured.md
+++ b/docs/tags/featured.md
@@ -6,5 +6,5 @@ hide:
 
 # featured
 
-- [Pull_Sentinal2_l2_data](/data-library/Pull_Sentinal2_l2_data.md)  
+- [Pull_Sentinal2_l2_data](/data-library/Pull_Sentinal2_l2_data/)  
   <small></small>

--- a/docs/tags/fia.md
+++ b/docs/tags/fia.md
@@ -6,5 +6,5 @@ hide:
 
 # fia
 
-- [fia](/data-library/fia.md)  
+- [fia](/data-library/fia/)  
   <small></small>

--- a/docs/tags/fire.md
+++ b/docs/tags/fire.md
@@ -6,7 +6,7 @@ hide:
 
 # fire
 
-- [fire-cbi](/data-library/fire-cbi.md)  
+- [landfire-events](/data-library/landfire-events/)  
   <small></small>
-- [landfire-events](/data-library/landfire-events.md)  
+- [fire-cbi](/data-library/fire-cbi/)  
   <small></small>

--- a/docs/tags/forest.md
+++ b/docs/tags/forest.md
@@ -6,7 +6,7 @@ hide:
 
 # forest
 
-- [fia](/data-library/fia.md)  
+- [fia](/data-library/fia/)  
   <small></small>
-- [treemap](/data-library/treemap.md)  
+- [treemap](/data-library/treemap/)  
   <small></small>

--- a/docs/tags/gdal.md
+++ b/docs/tags/gdal.md
@@ -6,5 +6,5 @@ hide:
 
 # gdal
 
-- [mounting-via-vsi](/data-library/mounting-via-vsi.md)  
+- [mounting-via-vsi](/data-library/mounting-via-vsi/)  
   <small></small>

--- a/docs/tags/gedi.md
+++ b/docs/tags/gedi.md
@@ -6,5 +6,5 @@ hide:
 
 # gedi
 
-- [gedi](/data-library/gedi.md)  
+- [gedi](/data-library/gedi/)  
   <small></small>

--- a/docs/tags/inventory.md
+++ b/docs/tags/inventory.md
@@ -6,5 +6,5 @@ hide:
 
 # inventory
 
-- [fia](/data-library/fia.md)  
+- [fia](/data-library/fia/)  
   <small></small>

--- a/docs/tags/landcover.md
+++ b/docs/tags/landcover.md
@@ -6,5 +6,5 @@ hide:
 
 # landcover
 
-- [lcmap](/data-library/lcmap.md)  
+- [lcmap](/data-library/lcmap/)  
   <small></small>

--- a/docs/tags/landfire.md
+++ b/docs/tags/landfire.md
@@ -6,7 +6,7 @@ hide:
 
 # landfire
 
-- [disturbance-stack](/data-library/disturbance-stack.md)  
+- [landfire-events](/data-library/landfire-events/)  
   <small></small>
-- [landfire-events](/data-library/landfire-events.md)  
+- [disturbance-stack](/data-library/disturbance-stack/)  
   <small></small>

--- a/docs/tags/lidar.md
+++ b/docs/tags/lidar.md
@@ -6,5 +6,5 @@ hide:
 
 # lidar
 
-- [gedi](/data-library/gedi.md)  
+- [gedi](/data-library/gedi/)  
   <small></small>

--- a/docs/tags/modis.md
+++ b/docs/tags/modis.md
@@ -6,5 +6,5 @@ hide:
 
 # modis
 
-- [modis-vcf](/data-library/modis-vcf.md)  
+- [modis-vcf](/data-library/modis-vcf/)  
   <small></small>

--- a/docs/tags/oasis.md
+++ b/docs/tags/oasis.md
@@ -6,5 +6,5 @@ hide:
 
 # oasis
 
-- [Starting with OASIS](/quickstart/oasis.md)  
+- [Starting with OASIS](/quickstart/oasis/)  
   <small>2024-01-01</small>

--- a/docs/tags/quickstart.md
+++ b/docs/tags/quickstart.md
@@ -6,9 +6,9 @@ hide:
 
 # quickstart
 
-- [Starting with OASIS](/quickstart/oasis.md)  
+- [Starting with OASIS](/quickstart/oasis/)  
   <small>2024-01-01</small>
-- [how-to-use](/quickstart/data-library/how-to-use.md)  
+- [how-to-use](/quickstart/data-library/how-to-use/)  
   <small></small>
-- [how-to-contribute](/quickstart/data-library/how-to-contribute.md)  
+- [how-to-contribute](/quickstart/data-library/how-to-contribute/)  
   <small></small>

--- a/docs/tags/raster.md
+++ b/docs/tags/raster.md
@@ -6,11 +6,11 @@ hide:
 
 # raster
 
-- [example-container](/container-library/example-container.md)  
+- [example-workflow](/analytics-library/example-workflow/)  
   <small></small>
-- [example-workflow](/analytics-library/example-workflow.md)  
+- [lcmap](/data-library/lcmap/)  
   <small></small>
-- [lcmap](/data-library/lcmap.md)  
+- [example-container](/container-library/example-container/)  
   <small></small>
-- [advanced-textbook](/quickstart/advanced-textbook.md)  
+- [advanced-textbook](/quickstart/advanced-textbook/)  
   <small></small>

--- a/docs/tags/remote-sensing.md
+++ b/docs/tags/remote-sensing.md
@@ -6,11 +6,11 @@ hide:
 
 # remote-sensing
 
-- [Pull_Sentinal2_l2_data](/data-library/Pull_Sentinal2_l2_data.md)  
+- [lcmap](/data-library/lcmap/)  
   <small></small>
-- [lcmap](/data-library/lcmap.md)  
+- [Pull_Sentinal2_l2_data](/data-library/Pull_Sentinal2_l2_data/)  
   <small></small>
-- [modis-vcf](/data-library/modis-vcf.md)  
+- [modis-vcf](/data-library/modis-vcf/)  
   <small></small>
-- [treemap](/data-library/treemap.md)  
+- [treemap](/data-library/treemap/)  
   <small></small>

--- a/docs/tags/schedule.md
+++ b/docs/tags/schedule.md
@@ -6,5 +6,5 @@ hide:
 
 # schedule
 
-- [dev-schedule](/dev-schedule.md)  
+- [dev-schedule](/dev-schedule/)  
   <small>2025-08-14</small>

--- a/docs/tags/sentinel-2.md
+++ b/docs/tags/sentinel-2.md
@@ -6,5 +6,5 @@ hide:
 
 # sentinel-2
 
-- [Pull_Sentinal2_l2_data](/data-library/Pull_Sentinal2_l2_data.md)  
+- [Pull_Sentinal2_l2_data](/data-library/Pull_Sentinal2_l2_data/)  
   <small></small>

--- a/docs/tags/spatial.md
+++ b/docs/tags/spatial.md
@@ -6,5 +6,5 @@ hide:
 
 # spatial
 
-- [INLA — Drop-in Analytics Module](/analytics-library/inla.md)  
+- [INLA — Drop-in Analytics Module](/analytics-library/inla/)  
   <small></small>

--- a/docs/tags/spatiotemporal.md
+++ b/docs/tags/spatiotemporal.md
@@ -6,5 +6,5 @@ hide:
 
 # spatiotemporal
 
-- [INLA — Drop-in Analytics Module](/analytics-library/inla.md)  
+- [INLA — Drop-in Analytics Module](/analytics-library/inla/)  
   <small></small>

--- a/docs/tags/stac.md
+++ b/docs/tags/stac.md
@@ -6,7 +6,7 @@ hide:
 
 # stac
 
-- [stac_simple](/data-library/stac_simple.md)  
+- [stac_mount_save](/data-library/stac_mount_save/)  
   <small></small>
-- [stac_mount_save](/data-library/stac_mount_save.md)  
+- [stac_simple](/data-library/stac_simple/)  
   <small></small>

--- a/docs/tags/treemap.md
+++ b/docs/tags/treemap.md
@@ -6,5 +6,5 @@ hide:
 
 # treemap
 
-- [treemap](/data-library/treemap.md)  
+- [treemap](/data-library/treemap/)  
   <small></small>

--- a/docs/tags/tutorial.md
+++ b/docs/tags/tutorial.md
@@ -6,11 +6,11 @@ hide:
 
 # tutorial
 
-- [move-data-to-instance](/data-library/move-data-to-instance.md)  
+- [mounting-via-vsi](/data-library/mounting-via-vsi/)  
   <small></small>
-- [stac_simple](/data-library/stac_simple.md)  
+- [stac_mount_save](/data-library/stac_mount_save/)  
   <small></small>
-- [stac_mount_save](/data-library/stac_mount_save.md)  
+- [move-data-to-instance](/data-library/move-data-to-instance/)  
   <small></small>
-- [mounting-via-vsi](/data-library/mounting-via-vsi.md)  
+- [stac_simple](/data-library/stac_simple/)  
   <small></small>

--- a/docs/tags/usage.md
+++ b/docs/tags/usage.md
@@ -6,5 +6,5 @@ hide:
 
 # usage
 
-- [how-to-use](/quickstart/data-library/how-to-use.md)  
+- [how-to-use](/quickstart/data-library/how-to-use/)  
   <small></small>

--- a/docs/tags/usgs.md
+++ b/docs/tags/usgs.md
@@ -6,5 +6,5 @@ hide:
 
 # usgs
 
-- [lcmap](/data-library/lcmap.md)  
+- [lcmap](/data-library/lcmap/)  
   <small></small>

--- a/docs/tags/vegetation.md
+++ b/docs/tags/vegetation.md
@@ -6,5 +6,5 @@ hide:
 
 # vegetation
 
-- [modis-vcf](/data-library/modis-vcf.md)  
+- [modis-vcf](/data-library/modis-vcf/)  
   <small></small>

--- a/scripts/generate_tags.py
+++ b/scripts/generate_tags.py
@@ -78,6 +78,8 @@ for tag, items in tagmap.items():
     lines = ["---", f"title: {tag}", "hide:", "  - toc", "---", "", f"# {tag}", ""]
     for it in items_sorted:
         date_str = it["date"] if it["date"] else ""
-        lines.append(f"- [{it['title']}](/{it['path']})  \n  <small>{date_str}</small>")
+        # Build an absolute link without the .md extension so the site points to the rendered page
+        link_path = '/' + it['path'][:-3] + '/' if it['path'].endswith('.md') else '/' + it['path']
+        lines.append(f"- [{it['title']}]({link_path})  \n  <small>{date_str}</small>")
     with open(os.path.join(TAGS_DIR, f"{tag}.md"), "w", encoding="utf-8") as f:
         f.write("\n".join(lines))


### PR DESCRIPTION
## Summary
- generate tag pages with extension-less absolute links so entries resolve to final markdown
## Testing
- `python scripts/check_front_matter.py`
- `mkdocs build`


------
https://chatgpt.com/codex/tasks/task_e_689fb10d5f808325b313add27e618b56