### PR TITLE
Add analytics and data library tags

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -19,6 +19,8 @@ hide:
       <div class="tag-suggestions">
         <a href="./quickstart/" class="tag">Quickstart</a>
         <a href="./container-library/" class="tag">Containers</a>
+        <a href="./analytics-library/" class="tag">Analytics</a>
+        <a href="./data-library/" class="tag">Data Library</a>
         <a href="./resources/" class="tag">Resources</a>
       </div>
     </div>

--- a/docs/tags/analytics.md
+++ b/docs/tags/analytics.md
@@ -8,5 +8,5 @@ hide:
 
 - [INLA — Drop-in Analytics Module](/analytics-library/inla/)  
   <small></small>
-- [example-workflow](/analytics-library/example-workflow/)  
+- [example-workflow](/analytics-library/example-workflow/)
   <small></small>

--- a/docs/tags/data-library.md
+++ b/docs/tags/data-library.md
@@ -8,5 +8,5 @@ hide:
 
 - [how-to-use](/quickstart/data-library/how-to-use/)  
   <small></small>
-- [how-to-contribute](/quickstart/data-library/how-to-contribute/)  
+- [how-to-contribute](/quickstart/data-library/how-to-contribute/)
   <small></small>

--- a/docs/tags/index.md
+++ b/docs/tags/index.md
@@ -14,7 +14,7 @@ hide:
 - [cloud](cloud.md)
 - [container](container.md)
 - [contribution](contribution.md)
-- [data library](data library.md)
+- [data library](data-library.md)
 - [data-cubes](data-cubes.md)
 - [data-management](data-management.md)
 - [development](development.md)


### PR DESCRIPTION
## Summary
- Link analytics and data library from OASIS homepage tag suggestions
- Normalize data-library tag file name and update tag index
- Ensure analytics and data-library tag pages end with newlines

## Testing
- `pytest`
- `mkdocs build`


------
https://chatgpt.com/codex/tasks/task_e_68a3902069608325bccf67f89715b289