### PR TITLE
Fix library links in tags

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -19,8 +19,8 @@ hide:
       <div class="tag-suggestions">
         <a href="./quickstart/" class="tag">Quickstart</a>
         <a href="./container-library/" class="tag">Containers</a>
-        <a href="./analytics-library/" class="tag">Analytics</a>
-        <a href="./data-library/" class="tag">Data Library</a>
+        <a href="./quickstart/analytics-library/" class="tag">Analytics</a>
+        <a href="./quickstart/data-library/" class="tag">Data Library</a>
         <a href="./resources/" class="tag">Resources</a>
       </div>
     </div>
@@ -255,7 +255,7 @@ hide:
 <div class="library-gallery">
 
   <div class="library-item">
-    <a href="https://cu-esiil.github.io/data-library/" target="_blank">
+    <a href="https://cu-esiil.github.io/library/data/" target="_blank">
       <img src="https://github.com/CU-ESIIL/home/blob/main/docs/assets/thumbnails/data_library.jpeg?raw=true" alt="Data Library">
     </a>
     <p><strong>Data Library</strong></p>
@@ -263,7 +263,7 @@ hide:
   </div>
 
   <div class="library-item">
-    <a href="https://analytics-library.esiil.org" target="_blank">
+    <a href="https://cu-esiil.github.io/library/analytics/" target="_blank">
       <img src="https://github.com/CU-ESIIL/home/blob/main/docs/assets/thumbnails/analytics_library.jpeg?raw=true" alt="Analytics Library">
     </a>
     <p><strong>Analytics Library</strong></p>

--- a/docs/quickstart/analytics-library.md
+++ b/docs/quickstart/analytics-library.md
@@ -7,7 +7,7 @@ documented, saving you from reinventing common analysis steps.
 
 ## Show It
 Each workflow page includes step-by-step instructions and example outputs at
-the [Analytics Library](https://analytics-library.esiil.org). Many provide
+the [Analytics Library](https://cu-esiil.github.io/library/analytics/). Many provide
 Jupyter notebooks demonstrating how to use the functions.
 
 ## Do It

--- a/docs/quickstart/data-library/how-to-use.md
+++ b/docs/quickstart/data-library/how-to-use.md
@@ -19,7 +19,7 @@ dataset.
 
 ## Do It
 1. **Navigate to the site.** Go to the
-   [Data Library](https://cu-esiil.github.io/data-library/).
+   [Data Library](https://cu-esiil.github.io/library/data/).
 2. **Browse or search.** Look for a dataset that matches your project goals.
 3. **Open the dataset page.** Read the description and preview any available
    files.

--- a/docs/quickstart/data-library/index.md
+++ b/docs/quickstart/data-library/index.md
@@ -8,11 +8,11 @@ and ready-to-use code snippets.
 ## Show It
 Visit a dataset page to see descriptive metadata, citation information, and
 copy-and-paste code snippets, like on the
-[library homepage](https://cu-esiil.github.io/data-library/).
+[library homepage](https://cu-esiil.github.io/library/data/).
 
 ## Do It
 1. **Head to the site.** Open the
-   [Data Library](https://cu-esiil.github.io/data-library/).
+   [Data Library](https://cu-esiil.github.io/library/data/).
 2. **Search or browse.** Use search or tags to find a dataset relevant to your
    question.
 3. **Read the metadata.** Review the description, license, and code snippets.

--- a/docs/tags/Bayesian.md
+++ b/docs/tags/Bayesian.md
@@ -6,5 +6,5 @@ hide:
 
 # Bayesian
 
-- [INLA — Drop-in Analytics Module](/analytics-library/inla/)  
+- [INLA — Drop-in Analytics Module](/library/analytics/inla/)  
   <small></small>

--- a/docs/tags/GLMM.md
+++ b/docs/tags/GLMM.md
@@ -6,5 +6,5 @@ hide:
 
 # GLMM
 
-- [INLA — Drop-in Analytics Module](/analytics-library/inla/)  
+- [INLA — Drop-in Analytics Module](/library/analytics/inla/)  
   <small></small>

--- a/docs/tags/INLA.md
+++ b/docs/tags/INLA.md
@@ -6,5 +6,5 @@ hide:
 
 # INLA
 
-- [INLA — Drop-in Analytics Module](/analytics-library/inla/)  
+- [INLA — Drop-in Analytics Module](/library/analytics/inla/)  
   <small></small>

--- a/docs/tags/LGM.md
+++ b/docs/tags/LGM.md
@@ -6,5 +6,5 @@ hide:
 
 # LGM
 
-- [INLA — Drop-in Analytics Module](/analytics-library/inla/)  
+- [INLA — Drop-in Analytics Module](/library/analytics/inla/)  
   <small></small>

--- a/docs/tags/R.md
+++ b/docs/tags/R.md
@@ -6,5 +6,5 @@ hide:
 
 # R
 
-- [INLA — Drop-in Analytics Module](/analytics-library/inla/)  
+- [INLA — Drop-in Analytics Module](/library/analytics/inla/)  
   <small></small>

--- a/docs/tags/analytics.md
+++ b/docs/tags/analytics.md
@@ -6,7 +6,7 @@ hide:
 
 # analytics
 
-- [INLA — Drop-in Analytics Module](/analytics-library/inla/)  
+- [INLA — Drop-in Analytics Module](/library/analytics/inla/)  
   <small></small>
-- [example-workflow](/analytics-library/example-workflow/)
+- [example-workflow](/library/analytics/example-workflow/)
   <small></small>

--- a/docs/tags/biomass.md
+++ b/docs/tags/biomass.md
@@ -6,5 +6,5 @@ hide:
 
 # biomass
 
-- [gedi](/data-library/gedi/)  
+- [gedi](/library/data/gedi/)  
   <small></small>

--- a/docs/tags/burn-severity.md
+++ b/docs/tags/burn-severity.md
@@ -6,5 +6,5 @@ hide:
 
 # burn-severity
 
-- [fire-cbi](/data-library/fire-cbi/)  
+- [fire-cbi](/library/data/fire-cbi/)  
   <small></small>

--- a/docs/tags/climate.md
+++ b/docs/tags/climate.md
@@ -6,5 +6,5 @@ hide:
 
 # climate
 
-- [drought](/data-library/drought/)  
+- [drought](/library/data/drought/)  
   <small></small>

--- a/docs/tags/cloud.md
+++ b/docs/tags/cloud.md
@@ -6,5 +6,5 @@ hide:
 
 # cloud
 
-- [mounting-via-vsi](/data-library/mounting-via-vsi/)  
+- [mounting-via-vsi](/library/data/mounting-via-vsi/)  
   <small></small>

--- a/docs/tags/data-cubes.md
+++ b/docs/tags/data-cubes.md
@@ -6,5 +6,5 @@ hide:
 
 # data-cubes
 
-- [stac_mount_save](/data-library/stac_mount_save/)  
+- [stac_mount_save](/library/data/stac_mount_save/)  
   <small></small>

--- a/docs/tags/data-management.md
+++ b/docs/tags/data-management.md
@@ -6,5 +6,5 @@ hide:
 
 # data-management
 
-- [move-data-to-instance](/data-library/move-data-to-instance/)  
+- [move-data-to-instance](/library/data/move-data-to-instance/)  
   <small></small>

--- a/docs/tags/disturbance.md
+++ b/docs/tags/disturbance.md
@@ -6,7 +6,7 @@ hide:
 
 # disturbance
 
-- [landfire-events](/data-library/landfire-events/)  
+- [landfire-events](/library/data/landfire-events/)  
   <small></small>
-- [disturbance-stack](/data-library/disturbance-stack/)  
+- [disturbance-stack](/library/data/disturbance-stack/)  
   <small></small>

--- a/docs/tags/drought.md
+++ b/docs/tags/drought.md
@@ -6,7 +6,7 @@ hide:
 
 # drought
 
-- [drought](/data-library/drought/)  
+- [drought](/library/data/drought/)  
   <small></small>
-- [disturbance-stack](/data-library/disturbance-stack/)  
+- [disturbance-stack](/library/data/disturbance-stack/)  
   <small></small>

--- a/docs/tags/ecoregions.md
+++ b/docs/tags/ecoregions.md
@@ -6,5 +6,5 @@ hide:
 
 # ecoregions
 
-- [epa-ecoregions](/data-library/epa-ecoregions/)  
+- [epa-ecoregions](/library/data/epa-ecoregions/)  
   <small></small>

--- a/docs/tags/epa.md
+++ b/docs/tags/epa.md
@@ -6,5 +6,5 @@ hide:
 
 # epa
 
-- [epa-ecoregions](/data-library/epa-ecoregions/)  
+- [epa-ecoregions](/library/data/epa-ecoregions/)  
   <small></small>

--- a/docs/tags/example.md
+++ b/docs/tags/example.md
@@ -6,7 +6,7 @@ hide:
 
 # example
 
-- [example-workflow](/analytics-library/example-workflow/)  
+- [example-workflow](/library/analytics/example-workflow/)  
   <small></small>
 - [example-container](/container-library/example-container/)  
   <small></small>

--- a/docs/tags/featured.md
+++ b/docs/tags/featured.md
@@ -6,5 +6,5 @@ hide:
 
 # featured
 
-- [Pull_Sentinal2_l2_data](/data-library/Pull_Sentinal2_l2_data/)  
+- [Pull_Sentinal2_l2_data](/library/data/Pull_Sentinal2_l2_data/)  
   <small></small>

--- a/docs/tags/fia.md
+++ b/docs/tags/fia.md
@@ -6,5 +6,5 @@ hide:
 
 # fia
 
-- [fia](/data-library/fia/)  
+- [fia](/library/data/fia/)  
   <small></small>

--- a/docs/tags/fire.md
+++ b/docs/tags/fire.md
@@ -6,7 +6,7 @@ hide:
 
 # fire
 
-- [landfire-events](/data-library/landfire-events/)  
+- [landfire-events](/library/data/landfire-events/)  
   <small></small>
-- [fire-cbi](/data-library/fire-cbi/)  
+- [fire-cbi](/library/data/fire-cbi/)  
   <small></small>

--- a/docs/tags/forest.md
+++ b/docs/tags/forest.md
@@ -6,7 +6,7 @@ hide:
 
 # forest
 
-- [fia](/data-library/fia/)  
+- [fia](/library/data/fia/)  
   <small></small>
-- [treemap](/data-library/treemap/)  
+- [treemap](/library/data/treemap/)  
   <small></small>

--- a/docs/tags/gdal.md
+++ b/docs/tags/gdal.md
@@ -6,5 +6,5 @@ hide:
 
 # gdal
 
-- [mounting-via-vsi](/data-library/mounting-via-vsi/)  
+- [mounting-via-vsi](/library/data/mounting-via-vsi/)  
   <small></small>

--- a/docs/tags/gedi.md
+++ b/docs/tags/gedi.md
@@ -6,5 +6,5 @@ hide:
 
 # gedi
 
-- [gedi](/data-library/gedi/)  
+- [gedi](/library/data/gedi/)  
   <small></small>

--- a/docs/tags/inventory.md
+++ b/docs/tags/inventory.md
@@ -6,5 +6,5 @@ hide:
 
 # inventory
 
-- [fia](/data-library/fia/)  
+- [fia](/library/data/fia/)  
   <small></small>

--- a/docs/tags/landcover.md
+++ b/docs/tags/landcover.md
@@ -6,5 +6,5 @@ hide:
 
 # landcover
 
-- [lcmap](/data-library/lcmap/)  
+- [lcmap](/library/data/lcmap/)  
   <small></small>

--- a/docs/tags/landfire.md
+++ b/docs/tags/landfire.md
@@ -6,7 +6,7 @@ hide:
 
 # landfire
 
-- [landfire-events](/data-library/landfire-events/)  
+- [landfire-events](/library/data/landfire-events/)  
   <small></small>
-- [disturbance-stack](/data-library/disturbance-stack/)  
+- [disturbance-stack](/library/data/disturbance-stack/)  
   <small></small>

--- a/docs/tags/lidar.md
+++ b/docs/tags/lidar.md
@@ -6,5 +6,5 @@ hide:
 
 # lidar
 
-- [gedi](/data-library/gedi/)  
+- [gedi](/library/data/gedi/)  
   <small></small>

--- a/docs/tags/modis.md
+++ b/docs/tags/modis.md
@@ -6,5 +6,5 @@ hide:
 
 # modis
 
-- [modis-vcf](/data-library/modis-vcf/)  
+- [modis-vcf](/library/data/modis-vcf/)  
   <small></small>

--- a/docs/tags/raster.md
+++ b/docs/tags/raster.md
@@ -6,9 +6,9 @@ hide:
 
 # raster
 
-- [example-workflow](/analytics-library/example-workflow/)  
+- [example-workflow](/library/analytics/example-workflow/)  
   <small></small>
-- [lcmap](/data-library/lcmap/)  
+- [lcmap](/library/data/lcmap/)  
   <small></small>
 - [example-container](/container-library/example-container/)  
   <small></small>

--- a/docs/tags/remote-sensing.md
+++ b/docs/tags/remote-sensing.md
@@ -6,11 +6,11 @@ hide:
 
 # remote-sensing
 
-- [lcmap](/data-library/lcmap/)  
+- [lcmap](/library/data/lcmap/)  
   <small></small>
-- [Pull_Sentinal2_l2_data](/data-library/Pull_Sentinal2_l2_data/)  
+- [Pull_Sentinal2_l2_data](/library/data/Pull_Sentinal2_l2_data/)  
   <small></small>
-- [modis-vcf](/data-library/modis-vcf/)  
+- [modis-vcf](/library/data/modis-vcf/)  
   <small></small>
-- [treemap](/data-library/treemap/)  
+- [treemap](/library/data/treemap/)  
   <small></small>

--- a/docs/tags/sentinel-2.md
+++ b/docs/tags/sentinel-2.md
@@ -6,5 +6,5 @@ hide:
 
 # sentinel-2
 
-- [Pull_Sentinal2_l2_data](/data-library/Pull_Sentinal2_l2_data/)  
+- [Pull_Sentinal2_l2_data](/library/data/Pull_Sentinal2_l2_data/)  
   <small></small>

--- a/docs/tags/spatial.md
+++ b/docs/tags/spatial.md
@@ -6,5 +6,5 @@ hide:
 
 # spatial
 
-- [INLA — Drop-in Analytics Module](/analytics-library/inla/)  
+- [INLA — Drop-in Analytics Module](/library/analytics/inla/)  
   <small></small>

--- a/docs/tags/spatiotemporal.md
+++ b/docs/tags/spatiotemporal.md
@@ -6,5 +6,5 @@ hide:
 
 # spatiotemporal
 
-- [INLA — Drop-in Analytics Module](/analytics-library/inla/)  
+- [INLA — Drop-in Analytics Module](/library/analytics/inla/)  
   <small></small>

--- a/docs/tags/stac.md
+++ b/docs/tags/stac.md
@@ -6,7 +6,7 @@ hide:
 
 # stac
 
-- [stac_mount_save](/data-library/stac_mount_save/)  
+- [stac_mount_save](/library/data/stac_mount_save/)  
   <small></small>
-- [stac_simple](/data-library/stac_simple/)  
+- [stac_simple](/library/data/stac_simple/)  
   <small></small>

--- a/docs/tags/treemap.md
+++ b/docs/tags/treemap.md
@@ -6,5 +6,5 @@ hide:
 
 # treemap
 
-- [treemap](/data-library/treemap/)  
+- [treemap](/library/data/treemap/)  
   <small></small>

--- a/docs/tags/tutorial.md
+++ b/docs/tags/tutorial.md
@@ -6,11 +6,11 @@ hide:
 
 # tutorial
 
-- [mounting-via-vsi](/data-library/mounting-via-vsi/)  
+- [mounting-via-vsi](/library/data/mounting-via-vsi/)  
   <small></small>
-- [stac_mount_save](/data-library/stac_mount_save/)  
+- [stac_mount_save](/library/data/stac_mount_save/)  
   <small></small>
-- [move-data-to-instance](/data-library/move-data-to-instance/)  
+- [move-data-to-instance](/library/data/move-data-to-instance/)  
   <small></small>
-- [stac_simple](/data-library/stac_simple/)  
+- [stac_simple](/library/data/stac_simple/)  
   <small></small>

--- a/docs/tags/usgs.md
+++ b/docs/tags/usgs.md
@@ -6,5 +6,5 @@ hide:
 
 # usgs
 
-- [lcmap](/data-library/lcmap/)  
+- [lcmap](/library/data/lcmap/)  
   <small></small>

--- a/docs/tags/vegetation.md
+++ b/docs/tags/vegetation.md
@@ -6,5 +6,5 @@ hide:
 
 # vegetation
 
-- [modis-vcf](/data-library/modis-vcf/)  
+- [modis-vcf](/library/data/modis-vcf/)  
   <small></small>

--- a/docs/worksheets/worksheet_2.md
+++ b/docs/worksheets/worksheet_2.md
@@ -60,7 +60,7 @@ Describe how your proposed project aligns with the Summit's themes of resilience
 
 
 ## Choosing Big Data Sets
-Explore potential data sets for your project's topic from the [data library](https://cu-esiil.github.io/data-library/). List your options below, organizing them by whether they represent the system you're studying (e.g., deciduous forests) or the disruption to it (e.g., wildfire). Then discuss your choices and indicate your final selections.
+Explore potential data sets for your project's topic from the [data library](https://cu-esiil.github.io/library/data/). List your options below, organizing them by whether they represent the system you're studying (e.g., deciduous forests) or the disruption to it (e.g., wildfire). Then discuss your choices and indicate your final selections.
 
 ### Draft Potential Data Sets
   - **System Being Perturbed/Disrupted:**

--- a/docs/worksheets/worksheet_5.md
+++ b/docs/worksheets/worksheet_5.md
@@ -54,7 +54,7 @@
 
 
 ### Which Big Data Sets
-- **Explore potential data sets for your project's topic from the [data library](https://cu-esiil.github.io/data-library/). List your options below, and after discussion and review, indicate your final choice for both the system being perturbed/disrupted and the perturbator/disrupter.**
+- **Explore potential data sets for your project's topic from the [data library](https://cu-esiil.github.io/library/data/). List your options below, and after discussion and review, indicate your final choice for both the system being perturbed/disrupted and the perturbator/disrupter.**
 
 #### Draft Potential Data Sets
   - **System Being Perturbed/Disrupted:**


### PR DESCRIPTION
## Summary
- update home page to link to new library subdirectories
- point quickstart pages and worksheets at consolidated Data and Analytics Library URLs
- fix tag pages so dataset and workflow links target /library/data/ and /library/analytics/

## Testing
- `mkdocs build`
- ❌ `pre-commit run --files $(git ls-files -m)` *(missing: pre-commit)*


------
https://chatgpt.com/codex/tasks/task_e_68a393d51d808325a8b868291e18570c