### PR TITLE
fix: update tag links with site base path

### DIFF
--- a/docs/tags/Bayesian.md
+++ b/docs/tags/Bayesian.md
@@ -6,5 +6,5 @@ hide:
 
 # Bayesian
 
-- [INLA — Drop-in Analytics Module](/library/analytics/inla/)  
+- [INLA — Drop-in Analytics Module](/home/library/analytics/inla/)  
   <small></small>

--- a/docs/tags/GLMM.md
+++ b/docs/tags/GLMM.md
@@ -6,5 +6,5 @@ hide:
 
 # GLMM
 
-- [INLA — Drop-in Analytics Module](/library/analytics/inla/)  
+- [INLA — Drop-in Analytics Module](/home/library/analytics/inla/)  
   <small></small>

--- a/docs/tags/INLA.md
+++ b/docs/tags/INLA.md
@@ -6,5 +6,5 @@ hide:
 
 # INLA
 
-- [INLA — Drop-in Analytics Module](/library/analytics/inla/)  
+- [INLA — Drop-in Analytics Module](/home/library/analytics/inla/)  
   <small></small>

--- a/docs/tags/LGM.md
+++ b/docs/tags/LGM.md
@@ -6,5 +6,5 @@ hide:
 
 # LGM
 
-- [INLA — Drop-in Analytics Module](/library/analytics/inla/)  
+- [INLA — Drop-in Analytics Module](/home/library/analytics/inla/)  
   <small></small>

--- a/docs/tags/R.md
+++ b/docs/tags/R.md
@@ -6,5 +6,5 @@ hide:
 
 # R
 
-- [INLA — Drop-in Analytics Module](/library/analytics/inla/)  
+- [INLA — Drop-in Analytics Module](/home/library/analytics/inla/)  
   <small></small>

--- a/docs/tags/analytics.md
+++ b/docs/tags/analytics.md
@@ -6,7 +6,7 @@ hide:
 
 # analytics
 
-- [INLA — Drop-in Analytics Module](/library/analytics/inla/)  
+- [INLA — Drop-in Analytics Module](/home/library/analytics/inla/)  
   <small></small>
-- [example-workflow](/library/analytics/example-workflow/)
+- [example-workflow](/home/library/analytics/example-workflow/)
   <small></small>

--- a/docs/tags/biomass.md
+++ b/docs/tags/biomass.md
@@ -6,5 +6,5 @@ hide:
 
 # biomass
 
-- [gedi](/library/data/gedi/)  
+- [gedi](/home/library/data/gedi/)  
   <small></small>

--- a/docs/tags/burn-severity.md
+++ b/docs/tags/burn-severity.md
@@ -6,5 +6,5 @@ hide:
 
 # burn-severity
 
-- [fire-cbi](/library/data/fire-cbi/)  
+- [fire-cbi](/home/library/data/fire-cbi/)  
   <small></small>

--- a/docs/tags/climate.md
+++ b/docs/tags/climate.md
@@ -6,5 +6,5 @@ hide:
 
 # climate
 
-- [drought](/library/data/drought/)  
+- [drought](/home/library/data/drought/)  
   <small></small>

--- a/docs/tags/cloud.md
+++ b/docs/tags/cloud.md
@@ -6,5 +6,5 @@ hide:
 
 # cloud
 
-- [mounting-via-vsi](/library/data/mounting-via-vsi/)  
+- [mounting-via-vsi](/home/library/data/mounting-via-vsi/)  
   <small></small>

--- a/docs/tags/container.md
+++ b/docs/tags/container.md
@@ -6,5 +6,5 @@ hide:
 
 # container
 
-- [example-container](/container-library/example-container/)  
+- [example-container](/home/container-library/example-container/)  
   <small></small>

--- a/docs/tags/contribution.md
+++ b/docs/tags/contribution.md
@@ -6,5 +6,5 @@ hide:
 
 # contribution
 
-- [how-to-contribute](/quickstart/data-library/how-to-contribute/)  
+- [how-to-contribute](/home/quickstart/data-library/how-to-contribute/)  
   <small></small>

--- a/docs/tags/data-cubes.md
+++ b/docs/tags/data-cubes.md
@@ -6,5 +6,5 @@ hide:
 
 # data-cubes
 
-- [stac_mount_save](/library/data/stac_mount_save/)  
+- [stac_mount_save](/home/library/data/stac_mount_save/)  
   <small></small>

--- a/docs/tags/data-library.md
+++ b/docs/tags/data-library.md
@@ -6,7 +6,7 @@ hide:
 
 # data library
 
-- [how-to-use](/quickstart/data-library/how-to-use/)  
+- [how-to-use](/home/quickstart/data-library/how-to-use/)  
   <small></small>
-- [how-to-contribute](/quickstart/data-library/how-to-contribute/)
+- [how-to-contribute](/home/quickstart/data-library/how-to-contribute/)
   <small></small>

--- a/docs/tags/data-management.md
+++ b/docs/tags/data-management.md
@@ -6,5 +6,5 @@ hide:
 
 # data-management
 
-- [move-data-to-instance](/library/data/move-data-to-instance/)  
+- [move-data-to-instance](/home/library/data/move-data-to-instance/)  
   <small></small>

--- a/docs/tags/development.md
+++ b/docs/tags/development.md
@@ -6,5 +6,5 @@ hide:
 
 # development
 
-- [dev-schedule](/dev-schedule/)  
+- [dev-schedule](/home/dev-schedule/)  
   <small>2025-08-14</small>

--- a/docs/tags/disturbance.md
+++ b/docs/tags/disturbance.md
@@ -6,7 +6,7 @@ hide:
 
 # disturbance
 
-- [landfire-events](/library/data/landfire-events/)  
+- [landfire-events](/home/library/data/landfire-events/)  
   <small></small>
-- [disturbance-stack](/library/data/disturbance-stack/)  
+- [disturbance-stack](/home/library/data/disturbance-stack/)  
   <small></small>

--- a/docs/tags/docker.md
+++ b/docs/tags/docker.md
@@ -6,5 +6,5 @@ hide:
 
 # docker
 
-- [Starting with OASIS](/quickstart/oasis/)  
+- [Starting with OASIS](/home/quickstart/oasis/)  
   <small>2024-01-01</small>

--- a/docs/tags/drought.md
+++ b/docs/tags/drought.md
@@ -6,7 +6,7 @@ hide:
 
 # drought
 
-- [drought](/library/data/drought/)  
+- [drought](/home/library/data/drought/)  
   <small></small>
-- [disturbance-stack](/library/data/disturbance-stack/)  
+- [disturbance-stack](/home/library/data/disturbance-stack/)  
   <small></small>

--- a/docs/tags/ecoregions.md
+++ b/docs/tags/ecoregions.md
@@ -6,5 +6,5 @@ hide:
 
 # ecoregions
 
-- [epa-ecoregions](/library/data/epa-ecoregions/)  
+- [epa-ecoregions](/home/library/data/epa-ecoregions/)  
   <small></small>

--- a/docs/tags/education.md
+++ b/docs/tags/education.md
@@ -6,5 +6,5 @@ hide:
 
 # education
 
-- [advanced-textbook](/quickstart/advanced-textbook/)  
+- [advanced-textbook](/home/quickstart/advanced-textbook/)  
   <small></small>

--- a/docs/tags/epa.md
+++ b/docs/tags/epa.md
@@ -6,5 +6,5 @@ hide:
 
 # epa
 
-- [epa-ecoregions](/library/data/epa-ecoregions/)  
+- [epa-ecoregions](/home/library/data/epa-ecoregions/)  
   <small></small>

--- a/docs/tags/example.md
+++ b/docs/tags/example.md
@@ -6,7 +6,7 @@ hide:
 
 # example
 
-- [example-workflow](/library/analytics/example-workflow/)  
+- [example-workflow](/home/library/analytics/example-workflow/)  
   <small></small>
-- [example-container](/container-library/example-container/)  
+- [example-container](/home/container-library/example-container/)  
   <small></small>

--- a/docs/tags/featured.md
+++ b/docs/tags/featured.md
@@ -6,5 +6,5 @@ hide:
 
 # featured
 
-- [Pull_Sentinal2_l2_data](/library/data/Pull_Sentinal2_l2_data/)  
+- [Pull_Sentinal2_l2_data](/home/library/data/Pull_Sentinal2_l2_data/)  
   <small></small>

--- a/docs/tags/fia.md
+++ b/docs/tags/fia.md
@@ -6,5 +6,5 @@ hide:
 
 # fia
 
-- [fia](/library/data/fia/)  
+- [fia](/home/library/data/fia/)  
   <small></small>

--- a/docs/tags/fire.md
+++ b/docs/tags/fire.md
@@ -6,7 +6,7 @@ hide:
 
 # fire
 
-- [landfire-events](/library/data/landfire-events/)  
+- [landfire-events](/home/library/data/landfire-events/)  
   <small></small>
-- [fire-cbi](/library/data/fire-cbi/)  
+- [fire-cbi](/home/library/data/fire-cbi/)  
   <small></small>

--- a/docs/tags/forest.md
+++ b/docs/tags/forest.md
@@ -6,7 +6,7 @@ hide:
 
 # forest
 
-- [fia](/library/data/fia/)  
+- [fia](/home/library/data/fia/)  
   <small></small>
-- [treemap](/library/data/treemap/)  
+- [treemap](/home/library/data/treemap/)  
   <small></small>

--- a/docs/tags/gdal.md
+++ b/docs/tags/gdal.md
@@ -6,5 +6,5 @@ hide:
 
 # gdal
 
-- [mounting-via-vsi](/library/data/mounting-via-vsi/)  
+- [mounting-via-vsi](/home/library/data/mounting-via-vsi/)  
   <small></small>

--- a/docs/tags/gedi.md
+++ b/docs/tags/gedi.md
@@ -6,5 +6,5 @@ hide:
 
 # gedi
 
-- [gedi](/library/data/gedi/)  
+- [gedi](/home/library/data/gedi/)  
   <small></small>

--- a/docs/tags/inventory.md
+++ b/docs/tags/inventory.md
@@ -6,5 +6,5 @@ hide:
 
 # inventory
 
-- [fia](/library/data/fia/)  
+- [fia](/home/library/data/fia/)  
   <small></small>

--- a/docs/tags/landcover.md
+++ b/docs/tags/landcover.md
@@ -6,5 +6,5 @@ hide:
 
 # landcover
 
-- [lcmap](/library/data/lcmap/)  
+- [lcmap](/home/library/data/lcmap/)  
   <small></small>

--- a/docs/tags/landfire.md
+++ b/docs/tags/landfire.md
@@ -6,7 +6,7 @@ hide:
 
 # landfire
 
-- [landfire-events](/library/data/landfire-events/)  
+- [landfire-events](/home/library/data/landfire-events/)  
   <small></small>
-- [disturbance-stack](/library/data/disturbance-stack/)  
+- [disturbance-stack](/home/library/data/disturbance-stack/)  
   <small></small>

--- a/docs/tags/lidar.md
+++ b/docs/tags/lidar.md
@@ -6,5 +6,5 @@ hide:
 
 # lidar
 
-- [gedi](/library/data/gedi/)  
+- [gedi](/home/library/data/gedi/)  
   <small></small>

--- a/docs/tags/modis.md
+++ b/docs/tags/modis.md
@@ -6,5 +6,5 @@ hide:
 
 # modis
 
-- [modis-vcf](/library/data/modis-vcf/)  
+- [modis-vcf](/home/library/data/modis-vcf/)  
   <small></small>

--- a/docs/tags/oasis.md
+++ b/docs/tags/oasis.md
@@ -6,5 +6,5 @@ hide:
 
 # oasis
 
-- [Starting with OASIS](/quickstart/oasis/)  
+- [Starting with OASIS](/home/quickstart/oasis/)  
   <small>2024-01-01</small>

--- a/docs/tags/quickstart.md
+++ b/docs/tags/quickstart.md
@@ -6,9 +6,9 @@ hide:
 
 # quickstart
 
-- [Starting with OASIS](/quickstart/oasis/)  
+- [Starting with OASIS](/home/quickstart/oasis/)  
   <small>2024-01-01</small>
-- [how-to-use](/quickstart/data-library/how-to-use/)  
+- [how-to-use](/home/quickstart/data-library/how-to-use/)  
   <small></small>
-- [how-to-contribute](/quickstart/data-library/how-to-contribute/)  
+- [how-to-contribute](/home/quickstart/data-library/how-to-contribute/)  
   <small></small>

--- a/docs/tags/raster.md
+++ b/docs/tags/raster.md
@@ -6,11 +6,11 @@ hide:
 
 # raster
 
-- [example-workflow](/library/analytics/example-workflow/)  
+- [example-workflow](/home/library/analytics/example-workflow/)  
   <small></small>
-- [lcmap](/library/data/lcmap/)  
+- [lcmap](/home/library/data/lcmap/)  
   <small></small>
-- [example-container](/container-library/example-container/)  
+- [example-container](/home/container-library/example-container/)  
   <small></small>
-- [advanced-textbook](/quickstart/advanced-textbook/)  
+- [advanced-textbook](/home/quickstart/advanced-textbook/)  
   <small></small>

--- a/docs/tags/remote-sensing.md
+++ b/docs/tags/remote-sensing.md
@@ -6,11 +6,11 @@ hide:
 
 # remote-sensing
 
-- [lcmap](/library/data/lcmap/)  
+- [lcmap](/home/library/data/lcmap/)  
   <small></small>
-- [Pull_Sentinal2_l2_data](/library/data/Pull_Sentinal2_l2_data/)  
+- [Pull_Sentinal2_l2_data](/home/library/data/Pull_Sentinal2_l2_data/)  
   <small></small>
-- [modis-vcf](/library/data/modis-vcf/)  
+- [modis-vcf](/home/library/data/modis-vcf/)  
   <small></small>
-- [treemap](/library/data/treemap/)  
+- [treemap](/home/library/data/treemap/)  
   <small></small>

--- a/docs/tags/schedule.md
+++ b/docs/tags/schedule.md
@@ -6,5 +6,5 @@ hide:
 
 # schedule
 
-- [dev-schedule](/dev-schedule/)  
+- [dev-schedule](/home/dev-schedule/)  
   <small>2025-08-14</small>

--- a/docs/tags/sentinel-2.md
+++ b/docs/tags/sentinel-2.md
@@ -6,5 +6,5 @@ hide:
 
 # sentinel-2
 
-- [Pull_Sentinal2_l2_data](/library/data/Pull_Sentinal2_l2_data/)  
+- [Pull_Sentinal2_l2_data](/home/library/data/Pull_Sentinal2_l2_data/)  
   <small></small>

--- a/docs/tags/spatial.md
+++ b/docs/tags/spatial.md
@@ -6,5 +6,5 @@ hide:
 
 # spatial
 
-- [INLA — Drop-in Analytics Module](/library/analytics/inla/)  
+- [INLA — Drop-in Analytics Module](/home/library/analytics/inla/)  
   <small></small>

--- a/docs/tags/spatiotemporal.md
+++ b/docs/tags/spatiotemporal.md
@@ -6,5 +6,5 @@ hide:
 
 # spatiotemporal
 
-- [INLA — Drop-in Analytics Module](/library/analytics/inla/)  
+- [INLA — Drop-in Analytics Module](/home/library/analytics/inla/)  
   <small></small>

--- a/docs/tags/stac.md
+++ b/docs/tags/stac.md
@@ -6,7 +6,7 @@ hide:
 
 # stac
 
-- [stac_mount_save](/library/data/stac_mount_save/)  
+- [stac_mount_save](/home/library/data/stac_mount_save/)  
   <small></small>
-- [stac_simple](/library/data/stac_simple/)  
+- [stac_simple](/home/library/data/stac_simple/)  
   <small></small>

--- a/docs/tags/treemap.md
+++ b/docs/tags/treemap.md
@@ -6,5 +6,5 @@ hide:
 
 # treemap
 
-- [treemap](/library/data/treemap/)  
+- [treemap](/home/library/data/treemap/)  
   <small></small>

--- a/docs/tags/tutorial.md
+++ b/docs/tags/tutorial.md
@@ -6,11 +6,11 @@ hide:
 
 # tutorial
 
-- [mounting-via-vsi](/library/data/mounting-via-vsi/)  
+- [mounting-via-vsi](/home/library/data/mounting-via-vsi/)  
   <small></small>
-- [stac_mount_save](/library/data/stac_mount_save/)  
+- [stac_mount_save](/home/library/data/stac_mount_save/)  
   <small></small>
-- [move-data-to-instance](/library/data/move-data-to-instance/)  
+- [move-data-to-instance](/home/library/data/move-data-to-instance/)  
   <small></small>
-- [stac_simple](/library/data/stac_simple/)  
+- [stac_simple](/home/library/data/stac_simple/)  
   <small></small>

--- a/docs/tags/usage.md
+++ b/docs/tags/usage.md
@@ -6,5 +6,5 @@ hide:
 
 # usage
 
-- [how-to-use](/quickstart/data-library/how-to-use/)  
+- [how-to-use](/home/quickstart/data-library/how-to-use/)  
   <small></small>

--- a/docs/tags/usgs.md
+++ b/docs/tags/usgs.md
@@ -6,5 +6,5 @@ hide:
 
 # usgs
 
-- [lcmap](/library/data/lcmap/)  
+- [lcmap](/home/library/data/lcmap/)  
   <small></small>

--- a/docs/tags/vegetation.md
+++ b/docs/tags/vegetation.md
@@ -6,5 +6,5 @@ hide:
 
 # vegetation
 
-- [modis-vcf](/library/data/modis-vcf/)  
+- [modis-vcf](/home/library/data/modis-vcf/)  
   <small></small>


### PR DESCRIPTION
## Summary
- prefix tag page links with `/home/` to avoid 404s on GitHub Pages

## Testing
- `mkdocs build`


------
https://chatgpt.com/codex/tasks/task_e_68a39a53a508832591a695092d88266d