### PR TITLE
Add documentation placeholders with TODO stubs

### DIFF
--- a/docs/about/accessibility.md
+++ b/docs/about/accessibility.md
@@ -1,0 +1,20 @@
+---
+title: "Accessibility"
+description: "TODO: add description"
+tags: [TODO]
+---
+
+# Accessibility
+
+## Who is this for?
+
+TODO
+
+## What you'll find here
+
+- TODO
+
+## Next steps
+
+- [About](./index.md)
+- [Policies](./policies.md)

--- a/docs/about/citation.md
+++ b/docs/about/citation.md
@@ -1,0 +1,20 @@
+---
+title: "Citation"
+description: "TODO: add description"
+tags: [TODO]
+---
+
+# Citation
+
+## Who is this for?
+
+TODO
+
+## What you'll find here
+
+- TODO
+
+## Next steps
+
+- [About](./index.md)
+- [Policies](./policies.md)

--- a/docs/about/governance.md
+++ b/docs/about/governance.md
@@ -1,0 +1,20 @@
+---
+title: "Governance"
+description: "TODO: add description"
+tags: [TODO]
+---
+
+# Governance
+
+## Who is this for?
+
+TODO
+
+## What you'll find here
+
+- TODO
+
+## Next steps
+
+- [About](./index.md)
+- [Policies](./policies.md)

--- a/docs/about/index.md
+++ b/docs/about/index.md
@@ -1,0 +1,21 @@
+---
+title: "About"
+description: "TODO: add description"
+tags: [TODO]
+---
+
+# About
+
+## Who is this for?
+
+TODO
+
+## What you'll find here
+
+- TODO
+
+## Next steps
+
+- [Governance](./governance.md)
+- [Policies](./policies.md)
+- [Accessibility](./accessibility.md)

--- a/docs/about/policies.md
+++ b/docs/about/policies.md
@@ -1,0 +1,20 @@
+---
+title: "Policies"
+description: "TODO: add description"
+tags: [TODO]
+---
+
+# Policies
+
+## Who is this for?
+
+TODO
+
+## What you'll find here
+
+- TODO
+
+## Next steps
+
+- [About](./index.md)
+- [Governance](./governance.md)

--- a/docs/changelog/index.md
+++ b/docs/changelog/index.md
@@ -1,0 +1,20 @@
+---
+title: "Changelog"
+description: "TODO: add description"
+tags: [TODO]
+---
+
+# Changelog
+
+## Who is this for?
+
+TODO
+
+## What you'll find here
+
+- TODO
+
+## Next steps
+
+- [Roadmap](../roadmap/index.md)
+- [Contributing](../contributing.md)

--- a/docs/code-of-conduct.md
+++ b/docs/code-of-conduct.md
@@ -1,0 +1,20 @@
+---
+title: "Code of Conduct"
+description: "TODO: add description"
+tags: [TODO]
+---
+
+# Code of Conduct
+
+## Who is this for?
+
+TODO
+
+## What you'll find here
+
+- TODO
+
+## Next steps
+
+- [Contributing](./contributing.md)
+- [Support](./support/index.md)

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,21 @@
+---
+title: "Contributing"
+description: "TODO: add description"
+tags: [TODO]
+---
+
+# Contributing
+
+## Who is this for?
+
+TODO
+
+## What you'll find here
+
+- TODO
+
+## Next steps
+
+- [Code of Conduct](./code-of-conduct.md)
+- [Support](./support/index.md)
+- [Security](./security.md)

--- a/docs/library/analytics/contribute.md
+++ b/docs/library/analytics/contribute.md
@@ -1,0 +1,20 @@
+---
+title: "Contribute to Analytics Library"
+description: "TODO: add description"
+tags: [TODO]
+---
+
+# Contribute to Analytics Library
+
+## Who is this for?
+
+TODO
+
+## What you'll find here
+
+- TODO
+
+## Next steps
+
+- [Analytics Library](./index.md)
+- [Module Template](./module-template.md)

--- a/docs/library/analytics/index.md
+++ b/docs/library/analytics/index.md
@@ -1,0 +1,20 @@
+---
+title: "Analytics Library"
+description: "TODO: add description"
+tags: [TODO]
+---
+
+# Analytics Library
+
+## Who is this for?
+
+TODO
+
+## What you'll find here
+
+- TODO
+
+## Next steps
+
+- [Module Template](./module-template.md)
+- [Contribute](./contribute.md)

--- a/docs/library/analytics/module-template.md
+++ b/docs/library/analytics/module-template.md
@@ -1,0 +1,20 @@
+---
+title: "Analytics Module Template"
+description: "TODO: add description"
+tags: [TODO]
+---
+
+# Analytics Module Template
+
+## Who is this for?
+
+TODO
+
+## What you'll find here
+
+- TODO
+
+## Next steps
+
+- [Analytics Library](./index.md)
+- [Contribute](./contribute.md)

--- a/docs/library/containers/catalog.md
+++ b/docs/library/containers/catalog.md
@@ -1,0 +1,20 @@
+---
+title: "Container Catalog"
+description: "TODO: add description"
+tags: [TODO]
+---
+
+# Container Catalog
+
+## Who is this for?
+
+TODO
+
+## What you'll find here
+
+- TODO
+
+## Next steps
+
+- [Container Library](./index.md)
+- [Policies](./policies.md)

--- a/docs/library/containers/index.md
+++ b/docs/library/containers/index.md
@@ -1,0 +1,20 @@
+---
+title: "Container Library"
+description: "TODO: add description"
+tags: [TODO]
+---
+
+# Container Library
+
+## Who is this for?
+
+TODO
+
+## What you'll find here
+
+- TODO
+
+## Next steps
+
+- [Policies](./policies.md)
+- [Catalog](./catalog.md)

--- a/docs/library/containers/policies.md
+++ b/docs/library/containers/policies.md
@@ -1,0 +1,20 @@
+---
+title: "Container Policies"
+description: "TODO: add description"
+tags: [TODO]
+---
+
+# Container Policies
+
+## Who is this for?
+
+TODO
+
+## What you'll find here
+
+- TODO
+
+## Next steps
+
+- [Container Library](./index.md)
+- [Catalog](./catalog.md)

--- a/docs/library/data/contribute.md
+++ b/docs/library/data/contribute.md
@@ -1,0 +1,20 @@
+---
+title: "Contribute to Data Library"
+description: "TODO: add description"
+tags: [TODO]
+---
+
+# Contribute to Data Library
+
+## Who is this for?
+
+TODO
+
+## What you'll find here
+
+- TODO
+
+## Next steps
+
+- [Data Library](./index.md)
+- [Dataset Template](./dataset-template.md)

--- a/docs/library/data/dataset-template.md
+++ b/docs/library/data/dataset-template.md
@@ -1,0 +1,20 @@
+---
+title: "Dataset Template"
+description: "TODO: add description"
+tags: [TODO]
+---
+
+# Dataset Template
+
+## Who is this for?
+
+TODO
+
+## What you'll find here
+
+- TODO
+
+## Next steps
+
+- [Data Library](./index.md)
+- [Contribute](./contribute.md)

--- a/docs/library/data/index.md
+++ b/docs/library/data/index.md
@@ -1,0 +1,20 @@
+---
+title: "Data Library"
+description: "TODO: add description"
+tags: [TODO]
+---
+
+# Data Library
+
+## Who is this for?
+
+TODO
+
+## What you'll find here
+
+- TODO
+
+## Next steps
+
+- [Dataset Template](./dataset-template.md)
+- [Contribute](./contribute.md)

--- a/docs/quickstart/index.md
+++ b/docs/quickstart/index.md
@@ -212,3 +212,9 @@ title: Quick Start
     </div>
 
 </div>
+
+## TODO
+
+- [ ] Add "Who is this for?" section
+- [ ] Add "What you'll find here" details
+- [ ] Add "Next steps" links

--- a/docs/roadmap/index.md
+++ b/docs/roadmap/index.md
@@ -1,0 +1,20 @@
+---
+title: "Roadmap"
+description: "TODO: add description"
+tags: [TODO]
+---
+
+# Roadmap
+
+## Who is this for?
+
+TODO
+
+## What you'll find here
+
+- TODO
+
+## Next steps
+
+- [Changelog](../changelog/index.md)
+- [Contributing](../contributing.md)

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,20 @@
+---
+title: "Security"
+description: "TODO: add description"
+tags: [TODO]
+---
+
+# Security
+
+## Who is this for?
+
+TODO
+
+## What you'll find here
+
+- TODO
+
+## Next steps
+
+- [Support](./support/index.md)
+- [Contributing](./contributing.md)

--- a/docs/support/index.md
+++ b/docs/support/index.md
@@ -1,0 +1,21 @@
+---
+title: "Support"
+description: "TODO: add description"
+tags: [TODO]
+---
+
+# Support
+
+## Who is this for?
+
+TODO
+
+## What you'll find here
+
+- TODO
+
+## Next steps
+
+- [Contributing](../contributing.md)
+- [Code of Conduct](../code-of-conduct.md)
+- [Security](../security.md)

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -1,0 +1,20 @@
+---
+title: "Tutorials"
+description: "TODO: add description"
+tags: [TODO]
+---
+
+# Tutorials
+
+## Who is this for?
+
+TODO
+
+## What you'll find here
+
+- TODO
+
+## Next steps
+
+- [Quickstart](../quickstart/index.md)
+- [Support](../support/index.md)


### PR DESCRIPTION
## Summary
- add placeholder pages for About, Library sections, Tutorials, Roadmap, Changelog, Support, Contributing, Code of Conduct, and Security
- append TODO section to existing Quickstart page

## Testing
- `pre-commit run --files docs/about/index.md docs/about/governance.md docs/about/policies.md docs/about/accessibility.md docs/about/citation.md docs/library/data/index.md docs/library/data/dataset-template.md docs/library/data/contribute.md docs/library/analytics/index.md docs/library/analytics/module-template.md docs/library/analytics/contribute.md docs/library/containers/index.md docs/library/containers/policies.md docs/library/containers/catalog.md docs/tutorials/index.md docs/roadmap/index.md docs/changelog/index.md docs/support/index.md docs/contributing.md docs/code-of-conduct.md docs/security.md docs/quickstart/index.md` *(fails: command not found: pre-commit)*

------
https://chatgpt.com/codex/tasks/task_e_68a3a47b7388832598fb345336921c29