### PR TITLE
Fix mkdocs deployment by dropping unused plugins

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -45,8 +45,6 @@ plugins:
   - tags
   - git-revision-date-localized:
       fallback_to_build_date: true
-  - mkdocs-simple-hooks # placeholder
-  - redirects
 
 markdown_extensions:
   - admonition


### PR DESCRIPTION
## Summary
- remove unused `mkdocs-simple-hooks` and `redirects` plugins from mkdocs config

## Testing
- `pre-commit run --files mkdocs.yml` *(fails: command not found)*
- `mkdocs gh-deploy --force` *(fails: 'origin' does not appear to be a git repository)*

------
https://chatgpt.com/codex/tasks/task_e_68a3a9c2f2988325a55a85cb1a46525c