### PR TITLE
docs: add reusable snippet includes

### DIFF
--- a/docs/_includes/badges.md
+++ b/docs/_includes/badges.md
@@ -1,0 +1,13 @@
+{% include "callouts.md" %}
+
+{% macro stable() -%}
+<span style="background-color:#28a745;color:white;padding:2px 6px;border-radius:4px;font-size:0.85em;">Stable</span>
+{%- endmacro %}
+
+{% macro preview() -%}
+<span style="background-color:#17a2b8;color:white;padding:2px 6px;border-radius:4px;font-size:0.85em;">Preview</span>
+{%- endmacro %}
+
+{% macro archived() -%}
+<span style="background-color:#6c757d;color:white;padding:2px 6px;border-radius:4px;font-size:0.85em;">Archived</span>
+{%- endmacro %}

--- a/docs/_includes/callouts.md
+++ b/docs/_includes/callouts.md
@@ -1,0 +1,14 @@
+{% macro note() -%}
+!!! note "Note"
+    {{ caller() }}
+{%- endmacro %}
+
+{% macro tip() -%}
+!!! tip "Tip"
+    {{ caller() }}
+{%- endmacro %}
+
+{% macro caution() -%}
+!!! caution "Caution"
+    {{ caller() }}
+{%- endmacro %}

--- a/docs/_includes/next-steps.md
+++ b/docs/_includes/next-steps.md
@@ -1,0 +1,8 @@
+{% include "callouts.md" %}
+
+{% macro next_steps(links) -%}
+### Next steps
+{% for text, url in links %}
+- [{{ text }}]({{ url }})
+{% endfor %}
+{%- endmacro %}


### PR DESCRIPTION
## Summary
- add reusable Markdown snippets for callouts, badges and next steps
- include callouts macro in snippet files

## Testing
- `pre-commit run --files docs/_includes/callouts.md docs/_includes/badges.md docs/_includes/next-steps.md` *(fails: command not found)*
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit)*
- `mkdocs build` *(fails: Config value 'plugins': The "mkdocs-simple-hooks" plugin is not installed)*
- `pip install mkdocs-simple-hooks` *(fails: Could not find a version that satisfies the requirement mkdocs-simple-hooks)*

------
https://chatgpt.com/codex/tasks/task_e_68a3a95984e0832598239efe1a578084