### PR TITLE
Fix broken tag links to external libraries

### DIFF
--- a/docs/tags/Bayesian.md
+++ b/docs/tags/Bayesian.md
@@ -6,5 +6,5 @@ hide:
 
 # Bayesian
 
-- [INLA — Drop-in Analytics Module](/home/library/analytics/inla/)  
+- [INLA — Drop-in Analytics Module](https://cu-esiil.github.io/analytics-library/inla/)  
   <small></small>

--- a/docs/tags/GLMM.md
+++ b/docs/tags/GLMM.md
@@ -6,5 +6,5 @@ hide:
 
 # GLMM
 
-- [INLA — Drop-in Analytics Module](/home/library/analytics/inla/)  
+- [INLA — Drop-in Analytics Module](https://cu-esiil.github.io/analytics-library/inla/)  
   <small></small>

--- a/docs/tags/INLA.md
+++ b/docs/tags/INLA.md
@@ -6,5 +6,5 @@ hide:
 
 # INLA
 
-- [INLA — Drop-in Analytics Module](/home/library/analytics/inla/)  
+- [INLA — Drop-in Analytics Module](https://cu-esiil.github.io/analytics-library/inla/)  
   <small></small>

--- a/docs/tags/LGM.md
+++ b/docs/tags/LGM.md
@@ -6,5 +6,5 @@ hide:
 
 # LGM
 
-- [INLA — Drop-in Analytics Module](/home/library/analytics/inla/)  
+- [INLA — Drop-in Analytics Module](https://cu-esiil.github.io/analytics-library/inla/)  
   <small></small>

--- a/docs/tags/R.md
+++ b/docs/tags/R.md
@@ -6,5 +6,5 @@ hide:
 
 # R
 
-- [INLA — Drop-in Analytics Module](/home/library/analytics/inla/)  
+- [INLA — Drop-in Analytics Module](https://cu-esiil.github.io/analytics-library/inla/)  
   <small></small>

--- a/docs/tags/analytics.md
+++ b/docs/tags/analytics.md
@@ -6,7 +6,7 @@ hide:
 
 # analytics
 
-- [INLA — Drop-in Analytics Module](/home/library/analytics/inla/)  
+- [INLA — Drop-in Analytics Module](https://cu-esiil.github.io/analytics-library/inla/)  
   <small></small>
-- [example-workflow](/home/library/analytics/example-workflow/)
+- [example-workflow](https://cu-esiil.github.io/analytics-library/example-workflow/)
   <small></small>

--- a/docs/tags/biomass.md
+++ b/docs/tags/biomass.md
@@ -6,5 +6,5 @@ hide:
 
 # biomass
 
-- [gedi](/home/library/data/gedi/)  
+- [gedi](https://cu-esiil.github.io/data-library/gedi/)  
   <small></small>

--- a/docs/tags/burn-severity.md
+++ b/docs/tags/burn-severity.md
@@ -6,5 +6,5 @@ hide:
 
 # burn-severity
 
-- [fire-cbi](/home/library/data/fire-cbi/)  
+- [fire-cbi](https://cu-esiil.github.io/data-library/fire-cbi/)  
   <small></small>

--- a/docs/tags/climate.md
+++ b/docs/tags/climate.md
@@ -6,5 +6,5 @@ hide:
 
 # climate
 
-- [drought](/home/library/data/drought/)  
+- [drought](https://cu-esiil.github.io/data-library/drought/)  
   <small></small>

--- a/docs/tags/cloud.md
+++ b/docs/tags/cloud.md
@@ -6,5 +6,5 @@ hide:
 
 # cloud
 
-- [mounting-via-vsi](/home/library/data/mounting-via-vsi/)  
+- [mounting-via-vsi](https://cu-esiil.github.io/data-library/mounting-via-vsi/)  
   <small></small>

--- a/docs/tags/data-cubes.md
+++ b/docs/tags/data-cubes.md
@@ -6,5 +6,5 @@ hide:
 
 # data-cubes
 
-- [stac_mount_save](/home/library/data/stac_mount_save/)  
+- [stac_mount_save](https://cu-esiil.github.io/data-library/stac_mount_save/)  
   <small></small>

--- a/docs/tags/data-management.md
+++ b/docs/tags/data-management.md
@@ -6,5 +6,5 @@ hide:
 
 # data-management
 
-- [move-data-to-instance](/home/library/data/move-data-to-instance/)  
+- [move-data-to-instance](https://cu-esiil.github.io/data-library/move-data-to-instance/)  
   <small></small>

--- a/docs/tags/disturbance.md
+++ b/docs/tags/disturbance.md
@@ -6,7 +6,7 @@ hide:
 
 # disturbance
 
-- [landfire-events](/home/library/data/landfire-events/)  
+- [landfire-events](https://cu-esiil.github.io/data-library/landfire-events/)  
   <small></small>
-- [disturbance-stack](/home/library/data/disturbance-stack/)  
+- [disturbance-stack](https://cu-esiil.github.io/data-library/disturbance-stack/)  
   <small></small>

--- a/docs/tags/drought.md
+++ b/docs/tags/drought.md
@@ -6,7 +6,7 @@ hide:
 
 # drought
 
-- [drought](/home/library/data/drought/)  
+- [drought](https://cu-esiil.github.io/data-library/drought/)  
   <small></small>
-- [disturbance-stack](/home/library/data/disturbance-stack/)  
+- [disturbance-stack](https://cu-esiil.github.io/data-library/disturbance-stack/)  
   <small></small>

--- a/docs/tags/ecoregions.md
+++ b/docs/tags/ecoregions.md
@@ -6,5 +6,5 @@ hide:
 
 # ecoregions
 
-- [epa-ecoregions](/home/library/data/epa-ecoregions/)  
+- [epa-ecoregions](https://cu-esiil.github.io/data-library/epa-ecoregions/)  
   <small></small>

--- a/docs/tags/epa.md
+++ b/docs/tags/epa.md
@@ -6,5 +6,5 @@ hide:
 
 # epa
 
-- [epa-ecoregions](/home/library/data/epa-ecoregions/)  
+- [epa-ecoregions](https://cu-esiil.github.io/data-library/epa-ecoregions/)  
   <small></small>

--- a/docs/tags/example.md
+++ b/docs/tags/example.md
@@ -6,7 +6,7 @@ hide:
 
 # example
 
-- [example-workflow](/home/library/analytics/example-workflow/)  
+- [example-workflow](https://cu-esiil.github.io/analytics-library/example-workflow/)  
   <small></small>
 - [example-container](/home/container-library/example-container/)  
   <small></small>

--- a/docs/tags/featured.md
+++ b/docs/tags/featured.md
@@ -6,5 +6,5 @@ hide:
 
 # featured
 
-- [Pull_Sentinal2_l2_data](/home/library/data/Pull_Sentinal2_l2_data/)  
+- [Pull_Sentinal2_l2_data](https://cu-esiil.github.io/data-library/Pull_Sentinal2_l2_data/)  
   <small></small>

--- a/docs/tags/fia.md
+++ b/docs/tags/fia.md
@@ -6,5 +6,5 @@ hide:
 
 # fia
 
-- [fia](/home/library/data/fia/)  
+- [fia](https://cu-esiil.github.io/data-library/fia/)  
   <small></small>

--- a/docs/tags/fire.md
+++ b/docs/tags/fire.md
@@ -6,7 +6,7 @@ hide:
 
 # fire
 
-- [landfire-events](/home/library/data/landfire-events/)  
+- [landfire-events](https://cu-esiil.github.io/data-library/landfire-events/)  
   <small></small>
-- [fire-cbi](/home/library/data/fire-cbi/)  
+- [fire-cbi](https://cu-esiil.github.io/data-library/fire-cbi/)  
   <small></small>

--- a/docs/tags/forest.md
+++ b/docs/tags/forest.md
@@ -6,7 +6,7 @@ hide:
 
 # forest
 
-- [fia](/home/library/data/fia/)  
+- [fia](https://cu-esiil.github.io/data-library/fia/)  
   <small></small>
-- [treemap](/home/library/data/treemap/)  
+- [treemap](https://cu-esiil.github.io/data-library/treemap/)  
   <small></small>

--- a/docs/tags/gdal.md
+++ b/docs/tags/gdal.md
@@ -6,5 +6,5 @@ hide:
 
 # gdal
 
-- [mounting-via-vsi](/home/library/data/mounting-via-vsi/)  
+- [mounting-via-vsi](https://cu-esiil.github.io/data-library/mounting-via-vsi/)  
   <small></small>

--- a/docs/tags/gedi.md
+++ b/docs/tags/gedi.md
@@ -6,5 +6,5 @@ hide:
 
 # gedi
 
-- [gedi](/home/library/data/gedi/)  
+- [gedi](https://cu-esiil.github.io/data-library/gedi/)  
   <small></small>

--- a/docs/tags/inventory.md
+++ b/docs/tags/inventory.md
@@ -6,5 +6,5 @@ hide:
 
 # inventory
 
-- [fia](/home/library/data/fia/)  
+- [fia](https://cu-esiil.github.io/data-library/fia/)  
   <small></small>

--- a/docs/tags/landcover.md
+++ b/docs/tags/landcover.md
@@ -6,5 +6,5 @@ hide:
 
 # landcover
 
-- [lcmap](/home/library/data/lcmap/)  
+- [lcmap](https://cu-esiil.github.io/data-library/lcmap/)  
   <small></small>

--- a/docs/tags/landfire.md
+++ b/docs/tags/landfire.md
@@ -6,7 +6,7 @@ hide:
 
 # landfire
 
-- [landfire-events](/home/library/data/landfire-events/)  
+- [landfire-events](https://cu-esiil.github.io/data-library/landfire-events/)  
   <small></small>
-- [disturbance-stack](/home/library/data/disturbance-stack/)  
+- [disturbance-stack](https://cu-esiil.github.io/data-library/disturbance-stack/)  
   <small></small>

--- a/docs/tags/lidar.md
+++ b/docs/tags/lidar.md
@@ -6,5 +6,5 @@ hide:
 
 # lidar
 
-- [gedi](/home/library/data/gedi/)  
+- [gedi](https://cu-esiil.github.io/data-library/gedi/)  
   <small></small>

--- a/docs/tags/modis.md
+++ b/docs/tags/modis.md
@@ -6,5 +6,5 @@ hide:
 
 # modis
 
-- [modis-vcf](/home/library/data/modis-vcf/)  
+- [modis-vcf](https://cu-esiil.github.io/data-library/modis-vcf/)  
   <small></small>

--- a/docs/tags/raster.md
+++ b/docs/tags/raster.md
@@ -6,9 +6,9 @@ hide:
 
 # raster
 
-- [example-workflow](/home/library/analytics/example-workflow/)  
+- [example-workflow](https://cu-esiil.github.io/analytics-library/example-workflow/)  
   <small></small>
-- [lcmap](/home/library/data/lcmap/)  
+- [lcmap](https://cu-esiil.github.io/data-library/lcmap/)  
   <small></small>
 - [example-container](/home/container-library/example-container/)  
   <small></small>

--- a/docs/tags/remote-sensing.md
+++ b/docs/tags/remote-sensing.md
@@ -6,11 +6,11 @@ hide:
 
 # remote-sensing
 
-- [lcmap](/home/library/data/lcmap/)  
+- [lcmap](https://cu-esiil.github.io/data-library/lcmap/)  
   <small></small>
-- [Pull_Sentinal2_l2_data](/home/library/data/Pull_Sentinal2_l2_data/)  
+- [Pull_Sentinal2_l2_data](https://cu-esiil.github.io/data-library/Pull_Sentinal2_l2_data/)  
   <small></small>
-- [modis-vcf](/home/library/data/modis-vcf/)  
+- [modis-vcf](https://cu-esiil.github.io/data-library/modis-vcf/)  
   <small></small>
-- [treemap](/home/library/data/treemap/)  
+- [treemap](https://cu-esiil.github.io/data-library/treemap/)  
   <small></small>

--- a/docs/tags/sentinel-2.md
+++ b/docs/tags/sentinel-2.md
@@ -6,5 +6,5 @@ hide:
 
 # sentinel-2
 
-- [Pull_Sentinal2_l2_data](/home/library/data/Pull_Sentinal2_l2_data/)  
+- [Pull_Sentinal2_l2_data](https://cu-esiil.github.io/data-library/Pull_Sentinal2_l2_data/)  
   <small></small>

--- a/docs/tags/spatial.md
+++ b/docs/tags/spatial.md
@@ -6,5 +6,5 @@ hide:
 
 # spatial
 
-- [INLA — Drop-in Analytics Module](/home/library/analytics/inla/)  
+- [INLA — Drop-in Analytics Module](https://cu-esiil.github.io/analytics-library/inla/)  
   <small></small>

--- a/docs/tags/spatiotemporal.md
+++ b/docs/tags/spatiotemporal.md
@@ -6,5 +6,5 @@ hide:
 
 # spatiotemporal
 
-- [INLA — Drop-in Analytics Module](/home/library/analytics/inla/)  
+- [INLA — Drop-in Analytics Module](https://cu-esiil.github.io/analytics-library/inla/)  
   <small></small>

--- a/docs/tags/stac.md
+++ b/docs/tags/stac.md
@@ -6,7 +6,7 @@ hide:
 
 # stac
 
-- [stac_mount_save](/home/library/data/stac_mount_save/)  
+- [stac_mount_save](https://cu-esiil.github.io/data-library/stac_mount_save/)  
   <small></small>
-- [stac_simple](/home/library/data/stac_simple/)  
+- [stac_simple](https://cu-esiil.github.io/data-library/stac_simple/)  
   <small></small>

--- a/docs/tags/treemap.md
+++ b/docs/tags/treemap.md
@@ -6,5 +6,5 @@ hide:
 
 # treemap
 
-- [treemap](/home/library/data/treemap/)  
+- [treemap](https://cu-esiil.github.io/data-library/treemap/)  
   <small></small>

--- a/docs/tags/tutorial.md
+++ b/docs/tags/tutorial.md
@@ -6,11 +6,11 @@ hide:
 
 # tutorial
 
-- [mounting-via-vsi](/home/library/data/mounting-via-vsi/)  
+- [mounting-via-vsi](https://cu-esiil.github.io/data-library/mounting-via-vsi/)  
   <small></small>
-- [stac_mount_save](/home/library/data/stac_mount_save/)  
+- [stac_mount_save](https://cu-esiil.github.io/data-library/stac_mount_save/)  
   <small></small>
-- [move-data-to-instance](/home/library/data/move-data-to-instance/)  
+- [move-data-to-instance](https://cu-esiil.github.io/data-library/move-data-to-instance/)  
   <small></small>
-- [stac_simple](/home/library/data/stac_simple/)  
+- [stac_simple](https://cu-esiil.github.io/data-library/stac_simple/)  
   <small></small>

--- a/docs/tags/usgs.md
+++ b/docs/tags/usgs.md
@@ -6,5 +6,5 @@ hide:
 
 # usgs
 
-- [lcmap](/home/library/data/lcmap/)  
+- [lcmap](https://cu-esiil.github.io/data-library/lcmap/)  
   <small></small>

--- a/docs/tags/vegetation.md
+++ b/docs/tags/vegetation.md
@@ -6,5 +6,5 @@ hide:
 
 # vegetation
 
-- [modis-vcf](/home/library/data/modis-vcf/)  
+- [modis-vcf](https://cu-esiil.github.io/data-library/modis-vcf/)  
   <small></small>


### PR DESCRIPTION
## Summary
- fix tag page links to point at published Data Library pages
- fix tag page links to point at published Analytics Library pages

## Testing
- `pre-commit run --files docs/tags/analytics.md docs/tags/landfire.md` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4b186f50083259f9a401f1681c40f