### PR TITLE
Add cloud triangle intro to quickstart docs

### DIFF
--- a/docs/quickstart/cloud.md
+++ b/docs/quickstart/cloud.md
@@ -1,0 +1,23 @@
+---
+title: Introduction to the Cloud Triangle
+tags: [quickstart, cloud]
+date: 2024-01-01
+weight: 0.5
+---
+
+# Introduction to the Cloud Triangle
+
+This page will outline the relationship between a cloud compute instance, persistent storage, and GitHub.
+
+Detailed guidance and examples will be added in a future update.
+
+## Overview
+
+- **Cloud compute instance** – placeholder explanation
+- **Persistent storage** – placeholder explanation
+- **GitHub** – placeholder explanation
+
+## Next Steps
+
+Content for this section will describe how these components interact to support reproducible science.
+

--- a/docs/quickstart/index.md
+++ b/docs/quickstart/index.md
@@ -96,6 +96,7 @@ title: Quick Start
     page walks you through the basics with step-by-step instructions and links
     for deeper learning.</p>
     <div class="tag-cloud" role="navigation" aria-label="Tag cloud">
+      <a href="./cloud/">Cloud</a>
       <a href="./cyverse/">CyVerse</a>
       <a href="./r/">R</a>
       <a href="./python/">Python</a>
@@ -116,6 +117,15 @@ title: Quick Start
           <div class="label">QUICK START PAGE</div>
           <div class="note">overview & orientation</div>
         </div>
+        <span class="chev" aria-hidden="true"></span>
+      </a>
+
+      <!-- Introduction to Cloud -->
+      <a class="pill" href="./cloud/" role="listitem" aria-label="Introduction to Cloud">
+        <div class="icon" aria-hidden="true">
+          <svg viewBox="0 0 24 24"><path d="M6 16h10a4 4 0 0 0 0-8 5.5 5.5 0 0 0-10.5 2A3.5 3.5 0 0 0 6 16z"/></svg>
+        </div>
+        <div class="label">Introduction to Cloud</div>
         <span class="chev" aria-hidden="true"></span>
       </a>
 

--- a/docs/tags/cloud.md
+++ b/docs/tags/cloud.md
@@ -6,5 +6,8 @@ hide:
 
 # cloud
 
-- [mounting-via-vsi](https://cu-esiil.github.io/data-library/mounting-via-vsi/)  
+- [mounting-via-vsi](https://cu-esiil.github.io/data-library/mounting-via-vsi/)
   <small></small>
+- [Introduction to the Cloud Triangle](/home/quickstart/cloud/)
+  <small>2024-01-01</small>
+

--- a/docs/tags/quickstart.md
+++ b/docs/tags/quickstart.md
@@ -6,9 +6,12 @@ hide:
 
 # quickstart
 
-- [Starting with OASIS](/home/quickstart/oasis/)  
+- [Starting with OASIS](/home/quickstart/oasis/)
   <small>2024-01-01</small>
-- [how-to-use](/home/quickstart/data-library/how-to-use/)  
+- [how-to-use](/home/quickstart/data-library/how-to-use/)
   <small></small>
-- [how-to-contribute](/home/quickstart/data-library/how-to-contribute/)  
+- [how-to-contribute](/home/quickstart/data-library/how-to-contribute/)
   <small></small>
+- [Introduction to the Cloud Triangle](/home/quickstart/cloud/)
+  <small>2024-01-01</small>
+


### PR DESCRIPTION
## Summary
- add placeholder quickstart page introducing the cloud triangle (compute instance, storage, GitHub)
- link new cloud page from quickstart index
- tag the page under quickstart and cloud sections

## Testing
- `pre-commit run --files docs/quickstart/cloud.md docs/quickstart/index.md docs/tags/cloud.md docs/tags/quickstart.md` *(fails: command not found)*
- `pip install pre-commit` *(fails: tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a8a79529dc83259a436dc48926e4c6