### PR TITLE
Automate development schedule updates and document pending tasks

### DIFF
--- a/docs/dev-schedule.md
+++ b/docs/dev-schedule.md
@@ -25,9 +25,12 @@ Since February 2025, OASIS has grown from an initial scaffold into a tagged docu
 
 ## Upcoming Task List
 
-- [ ] [Add GitHub linking to tasks](https://github.com/CU-ESIIL/home/issues/TBD)
-- [ ] [Automate Gantt chart updates](https://github.com/CU-ESIIL/home/issues/TBD)
-- [ ] [Interactive Cloud Triangle lesson](https://github.com/CU-ESIIL/home/issues/TBD)
+<!-- upcoming-start -->
+- [ ] [Add GitHub linking to tasks](https://github.com/CU-ESIIL/home/issues/60)
+- [ ] [Automate Gantt chart updates](https://github.com/CU-ESIIL/home/issues/61)
+- [ ] [Interactive Cloud Triangle lesson](https://github.com/CU-ESIIL/home/issues/62)
+<!-- upcoming-end -->
+
 
 ## Timeline Overview
 
@@ -65,9 +68,12 @@ gantt
     Cloud Triangle overview   :done, hist9, 2025-08-22, 1d
     Cloud Triangle examples   :done, hist10, 2025-08-22, 1d
     section Planned
-    GitHub link integration   :active, plan1, 2025-08-15, 6d
-    Auto Gantt updates        :       plan2, 2025-08-22, 5d
-    Interactive Cloud lesson  :       plan3, 2025-08-29, 5d
+<!-- gantt-start -->
+    Add GitHub linking to tasks  :active, plan1, 2025-08-15, 7d
+    Automate Gantt chart updates  : plan2, 2025-08-22, 5d
+    Interactive Cloud Triangle lesson  : plan3, 2025-08-29, 5d
+<!-- gantt-end -->
+
 ```
 
 <style>

--- a/docs/pending-tasks.md
+++ b/docs/pending-tasks.md
@@ -1,0 +1,22 @@
+---
+tags: [development]
+date: 2025-08-29
+---
+
+# Pending Development Tasks
+
+Some items from the development schedule remain outstanding. The notes below outline recommended steps for completing them.
+
+## Interactive Cloud Triangle lesson
+
+1. Design interactive plots using libraries such as Plotly or Altair to illustrate the Cloud Triangle concept.
+2. Host the interactive components as standalone HTML or within Jupyter notebooks and integrate them into the documentation with `mkdocs-jupyter` or embedded iframes.
+3. Provide explanatory text and data sources alongside the interactive elements.
+4. Link the lesson to the existing Cloud Triangle overview and examples pages.
+
+## Further automation
+
+- Enhance `scripts/update_dev_schedule.py` to fetch issue titles and status directly from the GitHub API.
+- Extend the script to update the timeline table in `docs/dev-schedule.md` for a fully automated roadmap.
+
+Running `python scripts/update_dev_schedule.py` will rebuild the upcoming task list and planned Gantt section from `docs/upcoming_tasks.yaml`.

--- a/docs/upcoming_tasks.yaml
+++ b/docs/upcoming_tasks.yaml
@@ -1,0 +1,14 @@
+upcoming_tasks:
+  - title: "Add GitHub linking to tasks"
+    issue: 60
+    start: 2025-08-15
+    end: 2025-08-21
+    active: true
+  - title: "Automate Gantt chart updates"
+    issue: 61
+    start: 2025-08-22
+    end: 2025-08-26
+  - title: "Interactive Cloud Triangle lesson"
+    issue: 62
+    start: 2025-08-29
+    end: 2025-09-02

--- a/scripts/update_dev_schedule.py
+++ b/scripts/update_dev_schedule.py
@@ -1,0 +1,62 @@
+import yaml
+from datetime import datetime
+import argparse
+import pathlib
+import re
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+DEV_SCHEDULE_PATH = ROOT / 'docs' / 'dev-schedule.md'
+TASKS_PATH = ROOT / 'docs' / 'upcoming_tasks.yaml'
+
+def load_tasks(path=TASKS_PATH):
+    with open(path) as f:
+        data = yaml.safe_load(f)
+    return data.get('upcoming_tasks', [])
+
+def format_upcoming(tasks):
+    lines = []
+    for t in tasks:
+        link = f"https://github.com/CU-ESIIL/home/issues/{t['issue']}"
+        lines.append(f"- [ ] [{t['title']}]({link})")
+    return "\n".join(lines)
+
+def format_gantt(tasks):
+    lines = []
+    for i, t in enumerate(tasks, 1):
+        start = datetime.strptime(str(t['start']), '%Y-%m-%d')
+        end = datetime.strptime(str(t['end']), '%Y-%m-%d')
+        duration = (end - start).days + 1
+        status = ':active,' if t.get('active') else ':'
+        lines.append(f"    {t['title']}  {status} plan{i}, {t['start']}, {duration}d")
+    return "\n".join(lines)
+
+def replace_section(content, start_marker, end_marker, replacement):
+    pattern = re.compile(
+        rf"({re.escape(start_marker)}\n)(.*?)(\n{re.escape(end_marker)})",
+        re.DOTALL,
+    )
+    return pattern.sub(rf"\1{replacement}\3", content)
+
+def update_dev_schedule(dev_path=DEV_SCHEDULE_PATH, tasks_path=TASKS_PATH):
+    tasks = load_tasks(tasks_path)
+    content = dev_path.read_text()
+    content = replace_section(
+        content,
+        '<!-- upcoming-start -->',
+        '<!-- upcoming-end -->',
+        format_upcoming(tasks),
+    )
+    content = replace_section(
+        content,
+        '<!-- gantt-start -->',
+        '<!-- gantt-end -->',
+        format_gantt(tasks),
+    )
+    dev_path.write_text(content)
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Update dev-schedule.md from YAML')
+    parser.add_argument('--tasks', default=TASKS_PATH, help='Path to tasks YAML')
+    parser.add_argument('--doc', default=DEV_SCHEDULE_PATH, help='Path to dev-schedule.md')
+    args = parser.parse_args()
+    update_dev_schedule(pathlib.Path(args.doc), pathlib.Path(args.tasks))


### PR DESCRIPTION
## Summary
- add `upcoming_tasks.yaml` and `update_dev_schedule.py` to generate issue links and Gantt entries
- refresh `docs/dev-schedule.md` with auto-generated task links and planned section
- document remaining work such as interactive Cloud Triangle lesson in `pending-tasks.md`

## Testing
- `python scripts/update_dev_schedule.py`
- `pre-commit run --files docs/dev-schedule.md docs/pending-tasks.md` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1cde8a63c8325bd845a019d4fc074