### PR TITLE
docs: track external development requests

### DIFF
--- a/docs/dev-requests.md
+++ b/docs/dev-requests.md
@@ -1,0 +1,12 @@
+---
+tags: [development, requests]
+date: 2025-08-29
+---
+
+# Development Requests
+
+A running list of development requests from collaborators and partner teams.
+
+- [ ] Data team: integrate repository with centralized dataset service
+- [ ] Learning team: add interactive tutorials for onboarding
+- [ ] Operations: improve deployment scripts and automation

--- a/docs/dev-schedule.md
+++ b/docs/dev-schedule.md
@@ -7,6 +7,8 @@ date: 2025-08-29
 
 A collaborative timeline for OASIS development. Update this page through pull requests and link to contributions as tasks are completed.
 
+See [Development Requests](dev-requests.md) for external requests made of the team.
+
 Since February 2025, OASIS has grown from an initial scaffold into a tagged documentation site. Late August 2025 added sidebar tag pages, fixed tag links, and launched the Cloud Triangle lesson with examples. Our next steps are to link tasks directly to GitHub issues and automate Gantt chart updates so the roadmap stays current.
 
 ## Historical Task List


### PR DESCRIPTION
## Summary
- add development requests page listing external team needs
- link dev schedule to the request list for easy reference

## Testing
- `pre-commit run --files docs/dev-schedule.md docs/dev-requests.md` *(fails: command not found)
- `pip install pre-commit` *(fails: Could not connect to proxy: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b1ce686ed8832594d04c1067f87875