### PR TITLE
Fix broken data library links after submodule change

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -19,8 +19,8 @@ hide:
       <div class="tag-suggestions">
         <a href="./quickstart/" class="tag">Quickstart</a>
         <a href="./container-library/" class="tag">Containers</a>
-        <a href="./quickstart/analytics-library/" class="tag">Analytics</a>
-        <a href="./quickstart/data-library/" class="tag">Data Library</a>
+        <a href="./analytics-library/" class="tag">Analytics</a>
+        <a href="./data-library/" class="tag">Data Library</a>
         <a href="./resources/" class="tag">Resources</a>
       </div>
     </div>

--- a/docs/tags/cloud.md
+++ b/docs/tags/cloud.md
@@ -8,6 +8,6 @@ hide:
 
 - [mounting-via-vsi](https://cu-esiil.github.io/data-library/mounting-via-vsi/)
   <small></small>
-- [Introduction to the Cloud Triangle](/home/quickstart/cloud/)
+- [Introduction to the Cloud Triangle](../quickstart/cloud/)
   <small>2024-01-01</small>
 

--- a/docs/tags/container.md
+++ b/docs/tags/container.md
@@ -6,5 +6,6 @@ hide:
 
 # container
 
-- [example-container](/home/container-library/example-container/)  
+- [example-container](../container-library/example-container/)
   <small></small>
+

--- a/docs/tags/contribution.md
+++ b/docs/tags/contribution.md
@@ -6,5 +6,6 @@ hide:
 
 # contribution
 
-- [how-to-contribute](/home/quickstart/data-library/how-to-contribute/)  
+- [how-to-contribute](../quickstart/data-library/how-to-contribute/)
   <small></small>
+

--- a/docs/tags/data-library.md
+++ b/docs/tags/data-library.md
@@ -6,7 +6,8 @@ hide:
 
 # data library
 
-- [how-to-use](/home/quickstart/data-library/how-to-use/)  
+- [how-to-use](../quickstart/data-library/how-to-use/)
   <small></small>
-- [how-to-contribute](/home/quickstart/data-library/how-to-contribute/)
+- [how-to-contribute](../quickstart/data-library/how-to-contribute/)
   <small></small>
+

--- a/docs/tags/development.md
+++ b/docs/tags/development.md
@@ -6,5 +6,6 @@ hide:
 
 # development
 
-- [dev-schedule](/home/dev-schedule/)  
+- [dev-schedule](../dev-schedule/)
   <small>2025-08-14</small>
+

--- a/docs/tags/docker.md
+++ b/docs/tags/docker.md
@@ -6,5 +6,6 @@ hide:
 
 # docker
 
-- [Starting with OASIS](/home/quickstart/oasis/)  
+- [Starting with OASIS](../quickstart/oasis/)
   <small>2024-01-01</small>
+

--- a/docs/tags/education.md
+++ b/docs/tags/education.md
@@ -6,5 +6,6 @@ hide:
 
 # education
 
-- [advanced-textbook](/home/quickstart/advanced-textbook/)  
+- [advanced-textbook](../quickstart/advanced-textbook/)
   <small></small>
+

--- a/docs/tags/example.md
+++ b/docs/tags/example.md
@@ -6,7 +6,8 @@ hide:
 
 # example
 
-- [example-workflow](https://cu-esiil.github.io/analytics-library/example-workflow/)  
+- [example-workflow](https://cu-esiil.github.io/analytics-library/example-workflow/)
   <small></small>
-- [example-container](/home/container-library/example-container/)  
+- [example-container](../container-library/example-container/)
   <small></small>
+

--- a/docs/tags/oasis.md
+++ b/docs/tags/oasis.md
@@ -6,5 +6,6 @@ hide:
 
 # oasis
 
-- [Starting with OASIS](/home/quickstart/oasis/)  
+- [Starting with OASIS](../quickstart/oasis/)
   <small>2024-01-01</small>
+

--- a/docs/tags/quickstart.md
+++ b/docs/tags/quickstart.md
@@ -6,12 +6,12 @@ hide:
 
 # quickstart
 
-- [Starting with OASIS](/home/quickstart/oasis/)
+- [Starting with OASIS](../quickstart/oasis/)
   <small>2024-01-01</small>
-- [how-to-use](/home/quickstart/data-library/how-to-use/)
+- [how-to-use](../quickstart/data-library/how-to-use/)
   <small></small>
-- [how-to-contribute](/home/quickstart/data-library/how-to-contribute/)
+- [how-to-contribute](../quickstart/data-library/how-to-contribute/)
   <small></small>
-- [Introduction to the Cloud Triangle](/home/quickstart/cloud/)
+- [Introduction to the Cloud Triangle](../quickstart/cloud/)
   <small>2024-01-01</small>
 

--- a/docs/tags/raster.md
+++ b/docs/tags/raster.md
@@ -6,11 +6,12 @@ hide:
 
 # raster
 
-- [example-workflow](https://cu-esiil.github.io/analytics-library/example-workflow/)  
+- [example-workflow](https://cu-esiil.github.io/analytics-library/example-workflow/)
   <small></small>
-- [lcmap](https://cu-esiil.github.io/data-library/lcmap/)  
+- [lcmap](https://cu-esiil.github.io/data-library/lcmap/)
   <small></small>
-- [example-container](/home/container-library/example-container/)  
+- [example-container](../container-library/example-container/)
   <small></small>
-- [advanced-textbook](/home/quickstart/advanced-textbook/)  
+- [advanced-textbook](../quickstart/advanced-textbook/)
   <small></small>
+

--- a/docs/tags/schedule.md
+++ b/docs/tags/schedule.md
@@ -6,5 +6,6 @@ hide:
 
 # schedule
 
-- [dev-schedule](/home/dev-schedule/)  
+- [dev-schedule](../dev-schedule/)
   <small>2025-08-14</small>
+

--- a/docs/tags/usage.md
+++ b/docs/tags/usage.md
@@ -6,5 +6,6 @@ hide:
 
 # usage
 
-- [how-to-use](/home/quickstart/data-library/how-to-use/)  
+- [how-to-use](../quickstart/data-library/how-to-use/)
   <small></small>
+


### PR DESCRIPTION
## Summary
- update docs index to point to analytics and data library subrepos
- replace old `/home/...` links with relative paths across tags

## Testing
- `pre-commit run --files docs/index.md docs/tags/cloud.md docs/tags/container.md docs/tags/contribution.md docs/tags/data-library.md docs/tags/development.md docs/tags/docker.md docs/tags/education.md docs/tags/example.md docs/tags/oasis.md docs/tags/quickstart.md docs/tags/raster.md docs/tags/schedule.md docs/tags/usage.md` *(fails: pre-commit not installed and installation blocked by proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68b1d53e89848325a40769166725b273