### PR TITLE
fix: update data library links

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -255,7 +255,7 @@ hide:
 <div class="library-gallery">
 
   <div class="library-item">
-    <a href="https://cu-esiil.github.io/library/data/" target="_blank">
+    <a href="https://cu-esiil.github.io/data-library/" target="_blank">
       <img src="https://github.com/CU-ESIIL/home/blob/main/docs/assets/thumbnails/data_library.jpeg?raw=true" alt="Data Library">
     </a>
     <p><strong>Data Library</strong></p>

--- a/docs/quickstart/data-library/how-to-use.md
+++ b/docs/quickstart/data-library/how-to-use.md
@@ -19,7 +19,7 @@ dataset.
 
 ## Do It
 1. **Navigate to the site.** Go to the
-   [Data Library](https://cu-esiil.github.io/library/data/).
+   [Data Library](https://cu-esiil.github.io/data-library/).
 2. **Browse or search.** Look for a dataset that matches your project goals.
 3. **Open the dataset page.** Read the description and preview any available
    files.

--- a/docs/quickstart/data-library/index.md
+++ b/docs/quickstart/data-library/index.md
@@ -8,11 +8,11 @@ and ready-to-use code snippets.
 ## Show It
 Visit a dataset page to see descriptive metadata, citation information, and
 copy-and-paste code snippets, like on the
-[library homepage](https://cu-esiil.github.io/library/data/).
+[library homepage](https://cu-esiil.github.io/data-library/).
 
 ## Do It
 1. **Head to the site.** Open the
-   [Data Library](https://cu-esiil.github.io/library/data/).
+   [Data Library](https://cu-esiil.github.io/data-library/).
 2. **Search or browse.** Use search or tags to find a dataset relevant to your
    question.
 3. **Read the metadata.** Review the description, license, and code snippets.

--- a/docs/worksheets/worksheet_2.md
+++ b/docs/worksheets/worksheet_2.md
@@ -60,7 +60,7 @@ Describe how your proposed project aligns with the Summit's themes of resilience
 
 
 ## Choosing Big Data Sets
-Explore potential data sets for your project's topic from the [data library](https://cu-esiil.github.io/library/data/). List your options below, organizing them by whether they represent the system you're studying (e.g., deciduous forests) or the disruption to it (e.g., wildfire). Then discuss your choices and indicate your final selections.
+Explore potential data sets for your project's topic from the [data library](https://cu-esiil.github.io/data-library/). List your options below, organizing them by whether they represent the system you're studying (e.g., deciduous forests) or the disruption to it (e.g., wildfire). Then discuss your choices and indicate your final selections.
 
 ### Draft Potential Data Sets
   - **System Being Perturbed/Disrupted:**

--- a/docs/worksheets/worksheet_5.md
+++ b/docs/worksheets/worksheet_5.md
@@ -54,7 +54,7 @@
 
 
 ### Which Big Data Sets
-- **Explore potential data sets for your project's topic from the [data library](https://cu-esiil.github.io/library/data/). List your options below, and after discussion and review, indicate your final choice for both the system being perturbed/disrupted and the perturbator/disrupter.**
+- **Explore potential data sets for your project's topic from the [data library](https://cu-esiil.github.io/data-library/). List your options below, and after discussion and review, indicate your final choice for both the system being perturbed/disrupted and the perturbator/disrupter.**
 
 #### Draft Potential Data Sets
   - **System Being Perturbed/Disrupted:**


### PR DESCRIPTION
## Summary
- fix Data & Analytics Libraries tile to point at new Data Library site
- update Quickstart and worksheet references to the new data library URL

## Testing
- `pre-commit run --files docs/index.md docs/quickstart/data-library/index.md docs/quickstart/data-library/how-to-use.md docs/worksheets/worksheet_2.md docs/worksheets/worksheet_5.md` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1db0d458c8325adba58215dca2cc1