### PR TITLE
Retitle Python quickstart to Data Exploration in the Cloud

### DIFF
--- a/docs/quickstart/index.md
+++ b/docs/quickstart/index.md
@@ -1,5 +1,7 @@
 ---
 title: Quick Start
+tags: [quickstart]
+date: 2024-01-01
 ---
 
 <style>
@@ -147,12 +149,12 @@ title: Quick Start
         <span class="chev" aria-hidden="true"></span>
       </a>
 
-      <!-- Starting with Python -->
-      <a class="pill is-sky" href="./python/" role="listitem" aria-label="Starting with Python">
+      <!-- Data Exploration in the Cloud -->
+      <a class="pill is-sky" href="./python/" role="listitem" aria-label="Data Exploration in the Cloud">
         <div class="icon" aria-hidden="true">
           <svg viewBox="0 0 24 24"><path d="M7 12a5 5 0 0 1 5-5h3a2 2 0 0 1 2 2v2H9a2 2 0 0 0 0 4h6"/><circle cx="14.5" cy="9.5" r=".75"/></svg>
         </div>
-        <div class="label">Starting with Python</div>
+        <div class="label">Data Exploration in the Cloud</div>
         <span class="chev" aria-hidden="true"></span>
       </a>
 

--- a/docs/quickstart/python.md
+++ b/docs/quickstart/python.md
@@ -1,34 +1,28 @@
-# Starting with Python
+---
+title: Creative Data Exploration in the Cloud
+tags: [cloud, GitHub, collaboration, time series, machine learning]
+date: 2024-01-01
+---
 
-## Sell It
-Python is a flexible language with a rich ecosystem of libraries for data
-science, web apps, and automation. Its clean syntax reads like English and it
-runs on every major operating system, making it a great first language for
-researchers and analysts.
+# Creative Data Exploration in the Cloud
 
-## Show It
-A minimal script prints a message, but even this tiny example demonstrates the
-language's readability:
+Today’s theme is **Creative Data Exploration in the Cloud** with a focus on **collaboration using GitHub**.  
+We’ll build skills step by step — each one necessary for the next — while working together in a shared environment.  
 
-```python
-print("Hello, OASIS!")
+---
+
+## 1. Opening the Lab Together: Startup Procedure
+
+Before we can explore, we need to get into the cloud.
+
+Follow the [OASIS QuickStart: Cloud Triangle](https://cu-esiil.github.io/home/quickstart/cloud/) instructions:
+
+- Log in to ACCESS-CI.  
+- Launch your JupyterHub instance.  
+- Confirm the Triangle is running.  
+- Open a terminal and check that `gocmd` is available:
+
+```bash
+gocmd --help
 ```
-
-## Do It
-1. **Install Python.** Download Python from the
-   [official site](https://www.python.org/) or install a distribution like
-   [Anaconda](https://www.anaconda.com/download) that bundles common tools.
-2. **Create an environment.** Use `conda create -n myenv python` or
-   `python -m venv myenv` to keep project packages isolated.
-3. **Activate the environment.** Run `conda activate myenv` or on macOS/Linux
-   `source myenv/bin/activate` (Windows: `myenv\Scripts\activate`).
-4. **Install a package.** Try `pip install pandas` to see how dependencies are
-   added.
-5. **Run the script.** Save the example above as `hello.py` and execute
-   `python hello.py`.
-
-## Review It
-Check `python --version` and run `pip list` to view installed packages. When
-you're done, deactivate the environment with `conda deactivate` or
-`deactivate` so your base system stays clean.
 


### PR DESCRIPTION
## Summary
- rename Quickstart menu label "Starting with Python" to "Data Exploration in the Cloud"
- replace old Python quickstart page with new creative cloud exploration guide
- add front matter metadata to quickstart index for site consistency

## Testing
- `pre-commit run --files docs/quickstart/index.md docs/quickstart/python.md` *(fails: command not found)*
- `pip install pre-commit` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c045270ee4832588ec53ff12a40833