### PR TITLE
style: improve home page tag button readability

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -66,14 +66,16 @@ hide:
   .tag-suggestions .tag {
     padding: 5px 12px;
     text-decoration: none;
-    border: 1px solid #ccc;
+    border: none;
     border-radius: 15px;
-    background: #f5f5f5;
-    color: #333;
+    background: #e0e0e0;
+    color: #000 !important;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
     font-size: 0.9em;
+    font-weight: 600;
   }
   .tag-suggestions .tag:hover {
-    background: #e0e0e0;
+    background: #d5d5d5;
   }
 </style>
 


### PR DESCRIPTION
## Summary
- restyle home page tag buttons with grey background and drop shadow for better contrast

## Testing
- `pre-commit run --files docs/index.md` *(failed: command not found)*
- `pip install pre-commit` *(failed: Could not find a version that satisfies the requirement pre-commit)*

------
https://chatgpt.com/codex/tasks/task_e_68c0a46adb748325be9b358767cc7e3b