### PR TITLE
fix: update analytics library link

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -265,7 +265,7 @@ hide:
   </div>
 
   <div class="library-item">
-    <a href="https://cu-esiil.github.io/library/analytics/" target="_blank">
+    <a href="https://cu-esiil.github.io/analytics-library/" target="_blank">
       <img src="https://github.com/CU-ESIIL/home/blob/main/docs/assets/thumbnails/analytics_library.jpeg?raw=true" alt="Analytics Library">
     </a>
     <p><strong>Analytics Library</strong></p>

--- a/docs/quickstart/analytics-library.md
+++ b/docs/quickstart/analytics-library.md
@@ -7,7 +7,7 @@ documented, saving you from reinventing common analysis steps.
 
 ## Show It
 Each workflow page includes step-by-step instructions and example outputs at
-the [Analytics Library](https://cu-esiil.github.io/library/analytics/). Many provide
+the [Analytics Library](https://cu-esiil.github.io/analytics-library/). Many provide
 Jupyter notebooks demonstrating how to use the functions.
 
 ## Do It


### PR DESCRIPTION
## Summary
- update analytics library docs to link to https://cu-esiil.github.io/analytics-library/

## Testing
- `pre-commit run --files docs/quickstart/analytics-library.md docs/index.md` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c47df22e34832588b0225e075eb669