### PR TITLE
Add animated contribute sticker near Quickstart CTA

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -81,16 +81,23 @@ hide:
 
 <!-- Quick Start Button -->
 <div class="qs-wrap">
-  <a class="qs-btn" href="./quickstart/" role="button" aria-label="Open Quick Start">
-    <img src="assets/thumbnails/quick_start_button.jpg" alt="Quick Start" />
-    <!-- Corner badge -->
-    <span class="qs-badge">CLICK</span>
-    <!-- Bottom CTA bar -->
-    <span class="qs-cta">
-      <span class="qs-icon">▶</span>
-      <span>Open Quick Start</span>
-    </span>
-  </a>
+  <div class="cta-wrap">
+    <a class="qs-btn quickstart-btn" href="./quickstart/" role="button" aria-label="Open Quick Start">
+      <img src="assets/thumbnails/quick_start_button.jpg" alt="Quick Start" />
+      <!-- Corner badge -->
+      <span class="qs-badge">CLICK</span>
+      <!-- Bottom CTA bar -->
+      <span class="qs-cta">
+        <span class="qs-icon">▶</span>
+        <span>Open Quick Start</span>
+      </span>
+    </a>
+
+    <!-- Sticker-style animated button -->
+    <a class="sticker-badge" href="https://cu-esiil.github.io/how_to_contribute/" aria-label="See how to contribute" title="See how to contribute">
+      Contribute
+    </a>
+  </div>
 </div>
 
 <style>

--- a/docs/styles/extra.css
+++ b/docs/styles/extra.css
@@ -1,0 +1,84 @@
+.cta-wrap {
+  position: relative;
+  display: inline-block;
+}
+
+.quickstart-btn {
+  display: inline-block;
+}
+
+.sticker-badge {
+  position: absolute;
+  top: -14px;
+  right: -10px;
+  z-index: 2;
+
+  display: inline-block;
+  padding: 0.5rem 0.7rem;
+  font-weight: 700;
+  font-size: 0.85rem;
+  line-height: 1;
+  text-decoration: none;
+
+  color: #111;
+  background: #ffd966;
+  border: 2px solid rgba(0, 0, 0, 0.15);
+  border-radius: 12px 18px 14px 16px;
+  box-shadow: 0 6px 14px rgba(0, 0, 0, 0.12), inset 0 1px 0 rgba(255, 255, 255, 0.35);
+
+  transform: rotate(-8deg);
+  transform-origin: 80% 20%;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  animation: sticker-float 3.2s ease-in-out infinite;
+}
+
+.sticker-badge::after {
+  content: "";
+  position: absolute;
+  bottom: -6px;
+  right: 12px;
+  width: 16px;
+  height: 10px;
+  background: radial-gradient(120% 100% at 50% 0%, rgba(0, 0, 0, 0.18), transparent 60%);
+  filter: blur(1px);
+  transform: rotate(8deg);
+  pointer-events: none;
+}
+
+.sticker-badge:hover,
+.sticker-badge:focus-visible {
+  transform: rotate(-4deg) translateY(-1px);
+  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.16), inset 0 1px 0 rgba(255, 255, 255, 0.4);
+  outline: none;
+}
+
+.sticker-badge:focus-visible {
+  box-shadow: 0 0 0 3px rgba(17, 17, 17, 0.15), 0 10px 20px rgba(0, 0, 0, 0.16), inset 0 1px 0 rgba(255, 255, 255, 0.4);
+}
+
+@keyframes sticker-float {
+  0% {
+    transform: rotate(-8deg) translateY(0);
+  }
+  50% {
+    transform: rotate(-7deg) translateY(-2px);
+  }
+  100% {
+    transform: rotate(-8deg) translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .sticker-badge {
+    animation: none;
+    transition: none;
+  }
+}
+
+@media (max-width: 520px) {
+  .sticker-badge {
+    top: -10px;
+    right: -6px;
+    font-size: 0.8rem;
+  }
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -156,6 +156,7 @@ markdown_extensions:
 extra_css:
   - assets/css/style.css
   - chatbot_widget.css
+  - styles/extra.css
 
 extra_javascript:
   - chatbot_widget.js


### PR DESCRIPTION
## Summary
- wrap the Quickstart call-to-action in a container so a new contribute sticker badge can sit near the corner
- add an animated sticker-style "Contribute" badge that links to the contribution guide without covering the Quickstart button
- provide external CSS and register it in MkDocs so the sticker animation and reduced-motion handling load site-wide

## Testing
- `mkdocs build`


------
https://chatgpt.com/codex/tasks/task_e_68c852a31d248325927290914d22a52c