### PR TITLE
Fix tag links and add resources landing page

### DIFF
--- a/docs/resources/index.md
+++ b/docs/resources/index.md
@@ -1,0 +1,31 @@
+---
+title: Resources
+---
+
+# Resources hub
+
+Explore curated guides, reference material, and notes that support the OASIS community. Use the collections below to jump to popular resources, or browse the Resources section in the navigation menu for the full list.
+
+## CyVerse how-to guides
+
+- [CyVerse basics](./cyverse_basics.md)
+- [Start a CyVerse instance](./cyverse_startup.md)
+- [Shut down your instance](./cyverse_shutdown.md)
+- [Move and save data in CyVerse](./cyverse_move_and_save_data.md)
+- [Stream data from CyVerse](./cyverse_stream_data.md)
+
+## Data skills and tooling
+
+- [Data analysis workflow](./data_analysis.md)
+- [Data processing essentials](./data_processing.md)
+- [Working with visualizations](./visualizations.md)
+- [Markdown basics](./markdown_basics.md)
+- [GitHub basics](./github_basics.md)
+
+## Notes and documentation
+
+- [ESIIL training overview](./esiil_training.md)
+- [Working groups and postdoc notes](./working_groups_and_postdocs.md)
+- [Meeting notes and agendas](./first_meeting_notes.md)
+
+Looking for something else? Check the navigation sidebar or use the site search to locate additional worksheets, reference material, and project documentation.

--- a/docs/tags/cloud.md
+++ b/docs/tags/cloud.md
@@ -8,6 +8,6 @@ hide:
 
 - [mounting-via-vsi](https://cu-esiil.github.io/data-library/library/mounting-via-vsi/)
   <small></small>
-- [Introduction to the Cloud Triangle](../quickstart/cloud/)
+- [Introduction to the Cloud Triangle](../../quickstart/cloud/)
   <small>2024-01-01</small>
 

--- a/docs/tags/container.md
+++ b/docs/tags/container.md
@@ -6,6 +6,6 @@ hide:
 
 # container
 
-- [example-container](../container-library/example-container/)
+- [example-container](../../container-library/example-container/)
   <small></small>
 

--- a/docs/tags/data-library.md
+++ b/docs/tags/data-library.md
@@ -6,7 +6,7 @@ hide:
 
 # data library
 
-- [how-to-use](../quickstart/data-library/how-to-use/)
+- [how-to-use](../../quickstart/data-library/how-to-use/)
   <small></small>
 - [how-to-contribute](https://cu-esiil.github.io/how_to_contribute/)
   <small></small>

--- a/docs/tags/development.md
+++ b/docs/tags/development.md
@@ -6,6 +6,6 @@ hide:
 
 # development
 
-- [dev-schedule](../dev-schedule/)
+- [dev-schedule](../../dev-schedule/)
   <small>2025-08-14</small>
 

--- a/docs/tags/docker.md
+++ b/docs/tags/docker.md
@@ -6,6 +6,6 @@ hide:
 
 # docker
 
-- [Starting with OASIS](../quickstart/oasis/)
+- [Starting with OASIS](../../quickstart/oasis/)
   <small>2024-01-01</small>
 

--- a/docs/tags/education.md
+++ b/docs/tags/education.md
@@ -6,6 +6,6 @@ hide:
 
 # education
 
-- [advanced-textbook](../quickstart/advanced-textbook/)
+- [advanced-textbook](../../quickstart/advanced-textbook/)
   <small></small>
 

--- a/docs/tags/example.md
+++ b/docs/tags/example.md
@@ -8,6 +8,6 @@ hide:
 
 - [example-workflow](https://cu-esiil.github.io/data-library/analytics/example-workflow/)
   <small></small>
-- [example-container](../container-library/example-container/)
+- [example-container](../../container-library/example-container/)
   <small></small>
 

--- a/docs/tags/oasis.md
+++ b/docs/tags/oasis.md
@@ -6,6 +6,6 @@ hide:
 
 # oasis
 
-- [Starting with OASIS](../quickstart/oasis/)
+- [Starting with OASIS](../../quickstart/oasis/)
   <small>2024-01-01</small>
 

--- a/docs/tags/quickstart.md
+++ b/docs/tags/quickstart.md
@@ -6,12 +6,12 @@ hide:
 
 # quickstart
 
-- [Starting with OASIS](../quickstart/oasis/)
+- [Starting with OASIS](../../quickstart/oasis/)
   <small>2024-01-01</small>
-- [how-to-use](../quickstart/data-library/how-to-use/)
+- [how-to-use](../../quickstart/data-library/how-to-use/)
   <small></small>
 - [how-to-contribute](https://cu-esiil.github.io/how_to_contribute/)
   <small></small>
-- [Introduction to the Cloud Triangle](../quickstart/cloud/)
+- [Introduction to the Cloud Triangle](../../quickstart/cloud/)
   <small>2024-01-01</small>
 

--- a/docs/tags/raster.md
+++ b/docs/tags/raster.md
@@ -10,8 +10,8 @@ hide:
   <small></small>
 - [lcmap](https://cu-esiil.github.io/data-library/library/lcmap/)
   <small></small>
-- [example-container](../container-library/example-container/)
+- [example-container](../../container-library/example-container/)
   <small></small>
-- [advanced-textbook](../quickstart/advanced-textbook/)
+- [advanced-textbook](../../quickstart/advanced-textbook/)
   <small></small>
 

--- a/docs/tags/schedule.md
+++ b/docs/tags/schedule.md
@@ -6,6 +6,6 @@ hide:
 
 # schedule
 
-- [dev-schedule](../dev-schedule/)
+- [dev-schedule](../../dev-schedule/)
   <small>2025-08-14</small>
 

--- a/docs/tags/usage.md
+++ b/docs/tags/usage.md
@@ -6,6 +6,6 @@ hide:
 
 # usage
 
-- [how-to-use](../quickstart/data-library/how-to-use/)
+- [how-to-use](../../quickstart/data-library/how-to-use/)
   <small></small>
 


### PR DESCRIPTION
## Summary
- fix broken relative links on tag pages so they resolve to the correct quickstart, dev schedule, and container library content
- add a resources landing page so the homepage “Resources” pill opens a valid page with curated links

## Testing
- mkdocs build

------
https://chatgpt.com/codex/tasks/task_e_68cc574820d4832594eedff2ab5e9c47