### PR TITLE
Fix homepage hero/sidebar overlap in desktop layout

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -3,6 +3,10 @@ hide:
   - toc
 ---
 
+<!-- Main Content -->
+<div class="oasis-layout" markdown="1">
+<main class="oasis-main" markdown="1">
+
 <div class="esiil-banner oasis-hero" markdown="1">
 <div class="esiil-banner__inner md-grid" markdown="1">
 <h1 class="oasis-header">Open Analysis and Synthesis Infrastructure for Science</h1>
@@ -25,10 +29,6 @@ hide:
 </div>
 </div>
 </div>
-
-<!-- Main Content -->
-<div class="oasis-layout" markdown="1">
-<main class="oasis-main" markdown="1">
 
 <style>
   .search-bar {

--- a/docs/styles/extra.css
+++ b/docs/styles/extra.css
@@ -9,6 +9,10 @@ body,
   line-height: 1.65;
 }
 
+:root{
+  --oasis-sidebar-w: 260px;
+}
+
 /* Headings */
 .md-typeset h1 {
   font-weight: 600;
@@ -261,7 +265,7 @@ body:has(.oasis-hero) .md-typeset h1 {
 }
 
 /* --- ESIIL-style banner hero (homepage) --- */
-body:has(.oasis-hero) .oasis-hero {
+body:has(.oasis-main .oasis-hero) .oasis-main .oasis-hero {
   margin-top: calc(var(--md-header-height, 3rem) * -1);
   padding-top: var(--md-header-height, 3rem);
 }
@@ -277,9 +281,9 @@ body:has(.oasis-hero) .md-content__inner {
 }
 
 .esiil-banner{
-  width: 100vw;
-  margin-left: calc(50% - 50vw);
-  margin-right: calc(50% - 50vw);
+  width: 100%;
+  margin-left: 0;
+  margin-right: 0;
   min-height: 520px;
 
   background:
@@ -326,4 +330,40 @@ body:has(.oasis-hero) .esiil-banner .esiil-kicker{
 .oasis-layout .md-content,
 .oasis-layout .md-content__inner {
   background: #fff;
+}
+
+@media (min-width: 60em){
+  .oasis-layout{
+    display: flex;
+    align-items: stretch;
+  }
+
+  .oasis-sidebar{
+    flex: 0 0 var(--oasis-sidebar-w);
+    width: var(--oasis-sidebar-w);
+    position: relative;
+    z-index: 2;
+  }
+
+  .oasis-main{
+    flex: 1 1 auto;
+    min-width: 0;
+    position: relative;
+    z-index: 1;
+  }
+
+  .oasis-main .oasis-hero{
+    width: 100%;
+    max-width: none;
+    margin-left: 0;
+    margin-right: 0;
+  }
+
+  .oasis-main .oasis-hero::before{
+    left: 0;
+    margin-left: 0;
+    right: 0;
+    margin-right: 0;
+    width: 100%;
+  }
 }


### PR DESCRIPTION
### Motivation
- The homepage hero was placed outside the two-column wrapper and visually extended underneath the left "Tags" sidebar at desktop widths. 
- Existing full-bleed hero rules (100vw / negative margins / pseudo-element) allowed the hero background to span beneath the sidebar instead of being constrained to the main content column.

### Description
- Moved the hero markup into the right column by wrapping the hero inside the `.oasis-layout > .oasis-main` container in `docs/index.md` so the hero sits within the main content column. 
- Added a single sidebar width variable `--oasis-sidebar-w` and authoritative desktop two-column flex layout in `docs/styles/extra.css`, defining `display:flex` on `.oasis-layout` and sizing for `.oasis-sidebar` and `.oasis-main`.
- Scoped the header-flush hero offset to `.oasis-main .oasis-hero` and removed the earlier `width:100vw` and negative margins, replacing them with `width:100%` and zeroed margins so the hero no longer forces a full-bleed layout. 
- Constrained any pseudo-element full-bleed behavior by adding `.oasis-main .oasis-hero::before` rules at desktop sizes so the hero background/pseudo-element starts at the main column left edge and does not extend under the sidebar.

### Testing
- Ran `mkdocs build` successfully to ensure the site builds with the CSS and markup changes. 
- Launched a dev server (`mkdocs serve`) and captured a desktop screenshot via Playwright to visually confirm the hero background and text no longer sit beneath the left tags sidebar. 
- Verified diffs for `docs/index.md` and `docs/styles/extra.css` to confirm the expected markup moves and CSS updates were applied.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699643421b208325afbd56bf0b2cb8d9)