### PR TITLE
Refactor homepage CSS: remove :has(), scope hero, and lock sidebar width

### DIFF
--- a/docs/styles/extra.css
+++ b/docs/styles/extra.css
@@ -10,7 +10,7 @@ body,
 }
 
 :root{
-  --oasis-sidebar-w: 260px;
+  --oasis-sidebar-w: 300px;
 }
 
 /* Headings */
@@ -60,7 +60,7 @@ body,
   padding-right: 2rem;
 }
 
-body:has(.oasis-hero) .md-content__inner {
+.oasis-layout .md-content__inner {
   padding-left: 0;
   padding-right: 0;
 }
@@ -253,30 +253,30 @@ button.md-button {
   padding-top: 4rem;
 }
 
-body:has(.oasis-hero) .md-content__inner {
+.oasis-layout .md-content__inner {
   padding-top: 0 !important;
   margin-top: 0 !important;
 }
 
-body:has(.oasis-hero) .md-typeset h1 {
+.oasis-layout .oasis-main .md-typeset h1 {
   margin-top: 2rem;
   margin-bottom: 1.5rem;
   font-weight: 600;
 }
 
 /* --- ESIIL-style banner hero (homepage) --- */
-body:has(.oasis-main .oasis-hero) .oasis-main .oasis-hero {
+.oasis-layout .oasis-main .oasis-hero {
   margin-top: calc(var(--md-header-height, 3rem) * -1);
   padding-top: var(--md-header-height, 3rem);
 }
 
-body:has(.oasis-hero) .md-main__inner {
+.oasis-layout .md-main__inner {
   margin-top: 0 !important;
   padding-top: 0 !important;
 }
 
-body:has(.oasis-hero) .md-content,
-body:has(.oasis-hero) .md-content__inner {
+.oasis-layout .md-content,
+.oasis-layout .md-content__inner {
   padding-top: 0 !important;
 }
 
@@ -318,7 +318,7 @@ body:has(.oasis-hero) .md-content__inner {
 }
 
 /* Optional: make the first small heading “WELCOME TO OASIS” match ESIIL style */
-body:has(.oasis-hero) .esiil-banner .esiil-kicker{
+.oasis-layout .oasis-main .esiil-banner .esiil-kicker{
   text-transform: uppercase;
   letter-spacing: 0.06em;
   font-weight: 700;
@@ -341,8 +341,13 @@ body:has(.oasis-hero) .esiil-banner .esiil-kicker{
   .oasis-sidebar{
     flex: 0 0 var(--oasis-sidebar-w);
     width: var(--oasis-sidebar-w);
+    overflow: hidden;
     position: relative;
     z-index: 2;
+  }
+
+  .oasis-sidebar *{
+    max-width: 100%;
   }
 
   .oasis-main{


### PR DESCRIPTION
### Motivation
- Remove fragile `:has()` selectors and scope homepage-only styles to a controlled structure so rules cannot leak to other pages.
- Keep the existing, working hero/header overlap behavior while simplifying selectors and preventing the hero from being positioned beneath the sidebar.
- Stabilize the sidebar width so it cannot expand and break layout on large screens.

### Description
- Replaced all `body:has(...)` homepage selectors in `docs/styles/extra.css` with structure-rooted selectors using `.oasis-layout` and `.oasis-main` (content padding, H1 spacing, hero spacing, and kicker styling now scoped to `.oasis-layout`).
- Kept the hero flush-to-header rule exactly as requested under `.oasis-layout .oasis-main .oasis-hero` using `margin-top: calc(var(--md-header-height, 3rem) * -1)` and `padding-top: var(--md-header-height, 3rem)`.
- Updated the sidebar width token to `--oasis-sidebar-w: 300px` and hardened desktop sidebar sizing with `overflow: hidden` and added `.oasis-sidebar * { max-width: 100%; }` to prevent children from forcing expansion.
- Ensured the hero remains confined to `.oasis-main` and did not reintroduce any `100vw` or negative viewport-offset tricks.

### Testing
- Ran `rg ':has\(' docs/styles/extra.css` and confirmed there are no `:has()` selectors remaining in the file.
- Ran `mkdocs build` successfully (build completes; existing documentation link warnings are pre-existing and unrelated).
- Launched a local server and captured a visual sanity-check screenshot (`mkdocs serve` + Playwright screenshot) to verify the hero touches the header, is not under the sidebar, and the sidebar width is stable; visual check succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996478a9d7c8325a9fc16009202c224)