### PR TITLE
Document homepage architecture and CSS guardrails for OASIS site edits

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,3 +24,12 @@ is present.
 
 Pages generated under `tags/` during the build are intentionally excluded from
 Git-based revision dates.
+
+
+## Homepage and layout edits
+
+Before editing homepage structure or CSS, read the canonical guide:
+
+- [`docs/dev/oasis-site-dev-guide.md`](docs/dev/oasis-site-dev-guide.md)
+
+Use that guide for layout architecture, selector rules, file ownership boundaries, and the homepage regression debug checklist.

--- a/README.md
+++ b/README.md
@@ -15,3 +15,9 @@ pip install -r requirements.txt
 python -m mkdocs serve -a localhost:8000
 ```
 Open a browser and go to https://localhost:8000 If something is already running on localhost:8000 just change the port in the command.
+
+## Homepage/layout development guidance
+
+For homepage architecture, hero/sidebar/header CSS rules, selector strategy, and Codex-safe prompts, use the canonical dev guide:
+
+- [`docs/dev/oasis-site-dev-guide.md`](docs/dev/oasis-site-dev-guide.md)

--- a/docs/assets/css/style.css
+++ b/docs/assets/css/style.css
@@ -1,4 +1,5 @@
-/* Structural layout quirks retained from legacy overrides */
+/* Structural compatibility glue only (legacy layout quirks).
+   Do not add brand/aesthetic styling here; put visual styling in docs/styles/extra.css. */
 
 /* Static header container/image behavior */
 .static-header {

--- a/docs/dev/oasis-site-dev-guide.md
+++ b/docs/dev/oasis-site-dev-guide.md
@@ -1,0 +1,179 @@
+# OASIS MkDocs Site Dev Guide (Homepage + Layout Safety)
+
+This is the canonical guide for homepage layout behavior, homepage CSS scoping, and Codex-safe editing patterns.
+
+Use this before touching:
+
+- `docs/index.md`
+- `docs/styles/extra.css`
+- `docs/assets/css/style.css`
+- `docs/overrides/main.html`
+- `mkdocs.yml`
+
+## Homepage layout architecture (current state)
+
+- The homepage uses a persistent two-column wrapper: `.oasis-layout` containing `.oasis-sidebar` (tags) + `.oasis-main` (main content).
+- The hero block (banner) **MUST** live inside `.oasis-layout > .oasis-main` to prevent overlap.
+- Sidebar width is controlled by `--oasis-sidebar-w` (currently `300px`) and is enforced at desktop widths via flex sizing.
+- Sidebar expansion is prevented via `overflow: hidden` and `max-width: 100%` on descendants.
+
+### Required structure in `docs/index.md`
+
+Keep the homepage shell in this form:
+
+```html
+<div class="oasis-layout" markdown="1">
+  <aside class="oasis-sidebar" markdown="1">...</aside>
+  <main class="oasis-main" markdown="1">
+    <div class="esiil-banner oasis-hero" markdown="1">...</div>
+    ...main homepage content...
+  </main>
+</div>
+```
+
+## Hero / header behavior rules (current working solution)
+
+- The hero is “flush to header” using this scoped rule:
+
+```css
+.oasis-layout .oasis-main .oasis-hero {
+  margin-top: calc(var(--md-header-height, 3rem) * -1);
+  padding-top: var(--md-header-height, 3rem);
+}
+```
+
+- We removed/avoided `100vw` full-bleed hero sizing and any `margin-left: calc(50% - 50vw)` tricks, because those caused hero underlap with the sidebar.
+- If a pseudo-element is used for hero backgrounds, it must be confined to `.oasis-main` (not viewport width).
+
+## Selector strategy (what to do / what NOT to do)
+
+- Do **NOT** use `:has()` for homepage scoping (brittle + can silently fail in tooling and cause no-ops).
+- Prefer scoping homepage-only rules using `.oasis-layout` as the homepage hook, since it only exists on `index.md`.
+- Be careful not to over-tighten selectors through `.oasis-main` when overriding Material container padding/margins.
+- The padding gap lives in Material containers and sometimes must be reset via:
+  - `.oasis-layout .md-main__inner`
+  - `.oasis-layout .md-content`
+  - `.oasis-layout .md-content__inner`
+
+### White-gap root cause (documented incident)
+
+The visible white strip above the hero came from `.md-content__inner` top padding.
+
+When this regresses, confirm the homepage-scoped reset is present:
+
+```css
+.oasis-layout .md-content__inner {
+  padding-top: 0 !important;
+  margin-top: 0 !important;
+}
+```
+
+## File responsibility boundaries
+
+- `docs/styles/extra.css` is the final-authority **brand skin** layer.
+- `docs/assets/css/style.css` should only contain legacy structural quirks (layout scaffolding), not aesthetic styling.
+- Rule of thumb:
+  - Visual/brand rule (color, surface, typography, polish, hero visual treatment) ➜ `extra.css`
+  - Structural compatibility glue (legacy selectors needed for behavior/layout compatibility) ➜ `style.css`
+
+Rationale: separating aesthetic intent from compatibility glue lowers regression risk when updating homepage visuals.
+
+## Debug checklist / playbook
+
+### If hero no longer touches header
+
+1. Check Material container padding resets on `.md-main__inner`, `.md-content`, and `.md-content__inner` under `.oasis-layout`.
+2. Confirm hero negative margin/padding rule still exists on `.oasis-layout .oasis-main .oasis-hero`.
+
+### If hero overlaps sidebar
+
+1. Confirm hero remains inside `.oasis-main` in `docs/index.md`.
+2. Confirm no `100vw` or `calc(50% - 50vw)` hero sizing rules were introduced.
+3. Confirm pseudo-element backgrounds are restricted to `.oasis-main` bounds.
+
+### If white strip returns above hero
+
+The `.md-content__inner` / `.md-main__inner` reset likely got over-scoped. Restore:
+
+```css
+.oasis-layout .md-content__inner { padding-top: 0 !important; }
+```
+
+(and ensure companion `.md-main__inner`/`.md-content` resets are still homepage-scoped).
+
+### If sidebar width changes unexpectedly
+
+1. Check `--oasis-sidebar-w` in `docs/styles/extra.css`.
+2. Check desktop flex-basis rule on `.oasis-sidebar`.
+3. Check `overflow: hidden` and descendant `max-width: 100%` rules.
+
+## Codex prompts we use
+
+### 1) Change hero without reintroducing gap
+
+```text
+Update the homepage hero styling in docs/styles/extra.css.
+Constraints:
+- Homepage-only changes (scope via .oasis-layout)
+- Do not use :has()
+- Keep hero inside .oasis-layout > .oasis-main
+- Preserve flush-header rule on .oasis-layout .oasis-main .oasis-hero
+- Do not use 100vw or calc(50% - 50vw)
+Validation:
+- Run mkdocs build and mkdocs serve commands
+- Report exactly which container padding resets were touched
+```
+
+### 2) Adjust sidebar width safely
+
+```text
+Change homepage sidebar width by editing --oasis-sidebar-w in docs/styles/extra.css.
+Constraints:
+- Homepage-only changes (scope via .oasis-layout)
+- Do not use :has()
+- Keep .oasis-sidebar flex-basis and width in sync with --oasis-sidebar-w
+- Keep overflow: hidden and descendant max-width: 100%
+Validation:
+- Run mkdocs build and mkdocs serve commands
+- Confirm hero does not overlap sidebar at desktop widths
+```
+
+### 3) Update hero background image/overlay
+
+```text
+Update the homepage hero background image/overlay in docs/styles/extra.css.
+Constraints:
+- Homepage-only changes (scope via .oasis-layout)
+- Do not use :has()
+- Keep .oasis-layout/.oasis-main structure unchanged
+- Do not introduce 100vw full-bleed or calc(50% - 50vw) rules
+- If using pseudo-elements, keep them confined to .oasis-main
+Validation:
+- Run mkdocs build and mkdocs serve commands
+- Verify no white strip above hero
+```
+
+### 4) Header/safari tint experiments (notes only)
+
+```text
+Propose (do not apply) experiments for header + Safari theme tint behavior.
+Constraints:
+- Notes only; no functional CSS layout refactor
+- Keep homepage rules scoped via .oasis-layout
+- Avoid :has()
+- Respect existing .oasis-layout/.oasis-main hero placement and flush-header rule
+Output:
+- 2-3 safe options with rollback notes
+- Include mkdocs build/serve validation plan
+```
+
+## What changed and why
+
+We iterated through homepage regressions (white top gap, hero/sidebar overlap, redundant sidebar layers, brittle selector scope) and stabilized on a layout-anchored approach:
+
+- homepage hook = `.oasis-layout`
+- hero constrained to `.oasis-main`
+- container resets scoped to homepage-only Material containers
+- explicit split between brand skin (`extra.css`) and legacy structure glue (`style.css`)
+
+This guide exists to preserve those decisions and prevent repeating the same regressions.

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,6 +4,7 @@ hide:
 ---
 
 <!-- Main Content -->
+<!-- Homepage contract: keep hero inside .oasis-layout > .oasis-main to avoid sidebar overlap regressions. -->
 <div class="oasis-layout" markdown="1">
 <main class="oasis-main" markdown="1">
 

--- a/docs/styles/extra.css
+++ b/docs/styles/extra.css
@@ -1,3 +1,4 @@
+/* Final authority for homepage visual/brand styling. Keep structural compatibility glue in docs/assets/css/style.css. */
 /* -------------------------------------------------
    Global Typography (ESIIL feel)
    ------------------------------------------------- */


### PR DESCRIPTION
### Motivation

- Capture the homepage/hero/sidebar/header layout decisions and the “rules of the road” discovered during recent iterations so future edits do not reintroduce regressions (white gap, hero/sidebar overlap, brittle selectors). 
- Provide a single canonical, machine- and human-readable source for safe homepage edits and Codex prompts so automated agents and contributors follow the same constraints. 

### Description

- Add a canonical developer guide at `docs/dev/oasis-site-dev-guide.md` that documents the two-column architecture (`.oasis-layout` → `.oasis-sidebar` + `.oasis-main`), the hero placement contract, sidebar sizing via `--oasis-sidebar-w`, the white-gap root cause and container resets, selector guidance (no `:has()`), file ownership rules (`docs/styles/extra.css` = brand skin, `docs/assets/css/style.css` = structural glue), a debug playbook, and 3–5 Codex-ready prompts. 
- Link the new guide from `README.md` and surface it in `CONTRIBUTING.md` so contributors are pointed to the single source of truth before editing homepage structure or CSS. 
- Add inline guard comments and ownership reminders: a homepage structure guard in `docs/index.md`, a visual-authority header in `docs/styles/extra.css`, and a structural-glue header in `docs/assets/css/style.css` to reduce ambiguity about where to place aesthetic vs structural rules. 
- Make only documentation and comment-level edits; no runtime/layout code changes were introduced beyond comments and the new guide (the guide references existing CSS rules such as `.oasis-layout .oasis-main .oasis-hero` and the `.oasis-layout .md-content__inner` reset). 

### Testing

- Built the site with `python -m mkdocs build` and the build completed successfully. 
- The build emitted unrelated repository warnings about nav/link hygiene and new-file git timestamps, but no errors related to the doc or CSS changes were observed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69964fd892c88325b993278f8ca7adb5)